### PR TITLE
Replace different frames by Simplebook

### DIFF
--- a/include/presentation/presentation.h
+++ b/include/presentation/presentation.h
@@ -2,6 +2,7 @@
 #define DIETAPP_INCLUDE_PRESENTATION_PRESENTATION_H
 
 #include <wx/filename.h>
+#include <wx/simplebook.h>
 #include <wx/wx.h>
 
 #include "core/application.h"
@@ -10,13 +11,24 @@ class Presentation {
  public:
   Presentation(Application* app);
 
-  bool Initialize(wxFileName& xrc_resources);
+  bool Initialize(wxFileName& xrc_resources, wxFrame* top_window);
+
+  void OnButtonRegister(wxCommandEvent& event);
+
+  wxFrame* GetMainFrame() { return main_frame_; }
+
+  wxButton* GetRegisterButton() { return register_button_; }
+
+  wxSimplebook* GetBook() { return book_; }
 
  private:
   Application* app_;
-  wxFrame initial_frame_;
-  wxFrame register_frame_;
-  wxFrame create_frame_;
+  wxFrame* main_frame_{nullptr};
+  wxButton* register_button_{nullptr};
+  wxSimplebook* book_{nullptr};
+  const int initial_page_idx_{0};
+  const int register_page_idx_{1};
+  const int create_page_idx_{2};
 };
 
 #endif  // DIETAPP_INCLUDE_PRESENTATION_PRESENTATION_H

--- a/src/core/application.cc
+++ b/src/core/application.cc
@@ -13,7 +13,7 @@ bool Application::OnInit() {
   /*TODO: Fix DB initialization */
   db_adapter_->Initialize("../schema-model/schema.sql");
   wxFileName xrc_resources;
-  presentation_->Initialize(xrc_resources);
+  presentation_->Initialize(xrc_resources, nullptr);
   return true;
 }
 

--- a/src/presentation/presentation.cc
+++ b/src/presentation/presentation.cc
@@ -1,3 +1,4 @@
+#include <wx/simplebook.h>
 #include <wx/stdpaths.h>
 #include <wx/wx.h>
 #include <wx/xrc/xmlres.h>
@@ -6,12 +7,15 @@
 
 Presentation::Presentation(Application* app) : app_(app) {}
 
-bool Presentation::Initialize(wxFileName& xrc_resources) {
+/*TODO: When running the bin of app a warning about the wxTestableFrame not
+        found is shown, but this does not affect the app per se, but anyway it
+        is anoying and should be removed */
+bool Presentation::Initialize(wxFileName& xrc_resources, wxFrame* top_window) {
 
-  wxXmlResource::Get()->InitAllHandlers();
   if (xrc_resources.IsOk()) {
-    wxXmlResource::Get()->Load(xrc_resources.GetFullPath());
+    main_frame_ = top_window;
   } else {
+    wxXmlResource::Get()->InitAllHandlers();
     wxStandardPaths& paths = wxStandardPaths::Get();
     xrc_resources = wxFileName(paths.GetDataDir(), "");
     xrc_resources.AppendDir("xrc");
@@ -19,10 +23,26 @@ bool Presentation::Initialize(wxFileName& xrc_resources) {
     wxXmlResource::Get()->Load(xrc_resources.GetFullPath());
   }
 
-  wxFrame* frame = wxXmlResource::Get()->LoadFrame(nullptr, "Initial");
-  if (frame == nullptr) {
+  if (top_window == nullptr) {
+    main_frame_ = wxXmlResource::Get()->LoadFrame(nullptr, "MainFrame");
+  }
+
+  register_button_ = XRCCTRL(*main_frame_, "m_buttonRegister", wxButton);
+  if (register_button_ == nullptr) {
     return false;
   }
-  frame->Show();
+  register_button_->Bind(wxEVT_BUTTON, &Presentation::OnButtonRegister, this,
+                         XRCID(register_button_->GetName()));
+
+  book_ = XRCCTRL(*main_frame_, "m_mainBook", wxSimplebook);
+  if (book_ == nullptr) {
+    return false;
+  }
+
+  main_frame_->Show();
   return true;
+}
+
+void Presentation::OnButtonRegister(wxCommandEvent& event) {
+  book_->SetSelection(register_page_idx_);
 }

--- a/src/presentation/xrc/resource.xrc
+++ b/src/presentation/xrc/resource.xrc
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <resource xmlns="http://www.wxwidgets.org/wxxrc" version="2.5.3.0">
-  <object class="wxFrame" name="Initial">
+  <object class="wxFrame" name="MainFrame" subclass="wxTestableFrame">
     <size>572,281</size>
     <style>wxDEFAULT_FRAME_STYLE|wxTAB_TRAVERSAL</style>
     <title></title>
     <centered>1</centered>
     <aui_managed>0</aui_managed>
-    <object class="wxMenuBar" name="m_menubar2">
+    <object class="wxMenuBar" name="m_menubar">
       <object class="wxMenu" name="m_menu1">
         <label>File</label>
         <object class="wxMenuItem" name="m_menuItem1">
@@ -19,335 +19,315 @@
         <label>Edit</label>
       </object>
     </object>
-    <object class="wxBoxSizer" name="bSizer3">
-      <orient>wxVERTICAL</orient>
-      <object class="sizeritem">
-        <flag>wxALL</flag>
-        <border>5</border>
-        <option>0</option>
-        <object class="wxStaticText" name="m_staticText4">
-          <label>Início</label>
-          <wrap>-1</wrap>
-        </object>
-      </object>
-      <object class="sizeritem">
-        <flag>wxEXPAND</flag>
-        <border>5</border>
-        <option>1</option>
-        <object class="wxGridSizer" name="gSizer14">
-          <rows>0</rows>
-          <cols>2</cols>
-          <vgap>0</vgap>
-          <hgap>0</hgap>
-          <object class="sizeritem">
-            <flag>wxALL|wxEXPAND</flag>
-            <border>5</border>
-            <option>1</option>
-            <object class="wxPanel" name="m_panel1">
-              <style>wxBORDER_SUNKEN|wxTAB_TRAVERSAL</style>
-              <object class="wxGridSizer" name="gSizer17">
-                <rows>1</rows>
-                <cols>1</cols>
-                <vgap>0</vgap>
-                <hgap>0</hgap>
-                <object class="sizeritem">
-                  <flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
-                  <border>5</border>
-                  <option>0</option>
-                  <object class="wxButton" name="m_button23">
-                    <label>Registrar</label>
-                    <default>0</default>
-                    <auth_needed>0</auth_needed>
-                    <markup>0</markup>
-                    <bitmap/>
-                  </object>
-                </object>
-              </object>
-            </object>
-          </object>
-          <object class="sizeritem">
-            <flag>wxEXPAND | wxALL</flag>
-            <border>5</border>
-            <option>1</option>
-            <object class="wxPanel" name="m_panel2">
-              <style>wxBORDER_SUNKEN|wxTAB_TRAVERSAL</style>
-              <object class="wxBoxSizer" name="bSizer11">
-                <orient>wxVERTICAL</orient>
-                <object class="sizeritem">
-                  <flag>wxALL|wxEXPAND</flag>
-                  <border>5</border>
-                  <option>1</option>
-                  <object class="wxStaticText" name="m_staticText7">
-                    <label>Dietas</label>
-                    <wrap>-1</wrap>
-                  </object>
-                </object>
-                <object class="sizeritem">
-                  <flag>wxALL|wxEXPAND</flag>
-                  <border>15</border>
-                  <option>9</option>
-                  <object class="wxListBox" name="m_listBox14">
-                    <style>wxLB_SINGLE</style>
-                    <content/>
-                  </object>
-                </object>
-              </object>
-            </object>
-          </object>
-        </object>
-      </object>
-    </object>
-  </object>
-  <object class="wxFrame" name="Register">
-    <size>566,281</size>
-    <style>wxDEFAULT_FRAME_STYLE|wxTAB_TRAVERSAL</style>
-    <title></title>
-    <centered>1</centered>
-    <aui_managed>0</aui_managed>
-    <object class="wxMenuBar" name="m_menubar2">
-      <object class="wxMenu" name="m_menu1">
-        <label>File</label>
-        <object class="wxMenuItem" name="m_menuItem1">
-          <label>Salvar</label>
-          <accel></accel>
-          <help></help>
-        </object>
-      </object>
-      <object class="wxMenu" name="m_menu2">
-        <label>Edit</label>
-      </object>
-    </object>
-    <object class="wxPanel" name="m_panel5">
-      <style>wxTAB_TRAVERSAL</style>
-      <object class="wxBoxSizer" name="bSizer8">
-        <orient>wxVERTICAL</orient>
-        <object class="sizeritem">
-          <flag>wxALL|wxEXPAND</flag>
-          <border>5</border>
-          <option>0</option>
-          <object class="wxStaticText" name="m_staticText8">
-            <label>Registrar</label>
-            <wrap>-1</wrap>
-          </object>
-        </object>
-        <object class="sizeritem">
-          <flag>wxEXPAND | wxALL</flag>
-          <border>5</border>
-          <option>1</option>
-          <object class="wxPanel" name="m_panel6">
-            <style>wxBORDER_SUNKEN|wxTAB_TRAVERSAL</style>
-            <object class="wxGridSizer" name="gSizer16">
-              <rows>3</rows>
-              <cols>2</cols>
-              <vgap>0</vgap>
-              <hgap>0</hgap>
-              <object class="sizeritem">
-                <flag>wxEXPAND | wxALL</flag>
-                <border>5</border>
-                <option>1</option>
-                <object class="wxPanel" name="m_panel8">
-                  <style>wxTAB_TRAVERSAL</style>
-                  <object class="wxGridSizer" name="gSizer6">
-                    <rows>1</rows>
-                    <cols>1</cols>
-                    <vgap>0</vgap>
-                    <hgap>0</hgap>
-                    <object class="sizeritem">
-                      <flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
-                      <border>5</border>
-                      <option>0</option>
-                      <object class="wxStaticText" name="m_staticText81">
-                        <label>Nome</label>
-                        <wrap>-1</wrap>
-                      </object>
-                    </object>
-                  </object>
-                </object>
-              </object>
-              <object class="sizeritem">
-                <flag>wxEXPAND | wxALL</flag>
-                <border>5</border>
-                <option>1</option>
-                <object class="wxPanel" name="m_panel9">
-                  <style>wxTAB_TRAVERSAL</style>
-                  <object class="wxGridSizer" name="gSizer7">
-                    <rows>1</rows>
-                    <cols>2</cols>
-                    <vgap>0</vgap>
-                    <hgap>0</hgap>
-                    <object class="sizeritem">
-                      <flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
-                      <border>5</border>
-                      <option>0</option>
-                      <object class="wxTextCtrl" name="m_textCtrl4">
-                        <value></value>
-                        <maxlength>0</maxlength>
-                      </object>
-                    </object>
-                  </object>
-                </object>
-              </object>
-              <object class="sizeritem">
-                <flag>wxEXPAND | wxALL</flag>
-                <border>5</border>
-                <option>1</option>
-                <object class="wxPanel" name="m_panel11">
-                  <style>wxTAB_TRAVERSAL</style>
-                  <object class="wxGridSizer" name="gSizer8">
-                    <rows>1</rows>
-                    <cols>1</cols>
-                    <vgap>0</vgap>
-                    <hgap>0</hgap>
-                    <object class="sizeritem">
-                      <flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
-                      <border>5</border>
-                      <option>0</option>
-                      <object class="wxStaticText" name="m_staticText9">
-                        <label>Refeição</label>
-                        <wrap>-1</wrap>
-                      </object>
-                    </object>
-                  </object>
-                </object>
-              </object>
-              <object class="sizeritem">
-                <flag>wxEXPAND | wxALL</flag>
-                <border>5</border>
-                <option>1</option>
-                <object class="wxPanel" name="m_panel12">
-                  <style>wxTAB_TRAVERSAL</style>
-                  <object class="wxGridSizer" name="gSizer9">
-                    <rows>1</rows>
-                    <cols>1</cols>
-                    <vgap>0</vgap>
-                    <hgap>0</hgap>
-                    <object class="sizeritem">
-                      <flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
-                      <border>5</border>
-                      <option>0</option>
-                      <object class="wxTextCtrl" name="m_textCtrl14">
-                        <value></value>
-                        <maxlength>0</maxlength>
-                      </object>
-                    </object>
-                  </object>
-                </object>
-              </object>
-              <object class="spacer">
-                <flag>wxEXPAND</flag>
-                <border>5</border>
-                <option>1</option>
-                <size>0,0</size>
-              </object>
-              <object class="sizeritem">
-                <flag>wxALL|wxALIGN_BOTTOM|wxALIGN_RIGHT</flag>
-                <border>5</border>
-                <option>0</option>
-                <object class="wxButton" name="m_button8">
-                  <label>Criar</label>
-                  <default>0</default>
-                  <auth_needed>0</auth_needed>
-                  <markup>0</markup>
-                  <bitmap/>
-                </object>
-              </object>
-            </object>
-          </object>
-        </object>
-      </object>
-    </object>
-  </object>
-  <object class="wxFrame" name="Create">
-    <size>566,281</size>
-    <style>wxDEFAULT_FRAME_STYLE|wxTAB_TRAVERSAL</style>
-    <title></title>
-    <centered>1</centered>
-    <aui_managed>0</aui_managed>
-    <object class="wxMenuBar" name="m_menubar2">
-      <object class="wxMenu" name="m_menu1">
-        <label>File</label>
-        <object class="wxMenuItem" name="m_menuItem1">
-          <label>Salvar</label>
-          <accel></accel>
-          <help></help>
-        </object>
-      </object>
-      <object class="wxMenu" name="m_menu2">
-        <label>Edit</label>
-      </object>
-    </object>
-    <object class="wxFlexGridSizer" name="fgSizer2">
-      <vgap>0</vgap>
-      <hgap>0</hgap>
-      <growablerows>1</growablerows>
-      <growablecols>0,1</growablecols>
-      <rows>2</rows>
-      <cols>2</cols>
-      <object class="sizeritem">
-        <flag>wxEXPAND | wxALL</flag>
-        <border>5</border>
-        <option>1</option>
-        <object class="wxPanel" name="m_panel7">
+    <object class="wxSimplebook" name="m_mainBook">
+      <object class="simplebookpage">
+        <label>a page</label>
+        <selected>0</selected>
+        <object class="wxPanel" name="m_panelPageInit">
           <style>wxTAB_TRAVERSAL</style>
-          <object class="wxGridSizer" name="gSizer4">
-            <rows>1</rows>
-            <cols>1</cols>
-            <vgap>0</vgap>
-            <hgap>0</hgap>
-            <object class="sizeritem">
-              <flag>wxALL|wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT</flag>
-              <border>5</border>
-              <option>0</option>
-              <object class="wxStaticText" name="m_staticText6">
-                <label>Refeições</label>
-                <wrap>-1</wrap>
-              </object>
-            </object>
-          </object>
-        </object>
-      </object>
-      <object class="sizeritem">
-        <flag>wxALL</flag>
-        <border>5</border>
-        <option>0</option>
-        <object class="wxChoice" name="m_choice5">
-          <selection>0</selection>
-          <content/>
-        </object>
-      </object>
-      <object class="sizeritem">
-        <flag>wxEXPAND | wxALL</flag>
-        <border>5</border>
-        <option>1</option>
-        <object class="wxPanel" name="m_panel11">
-          <style>wxBORDER_SUNKEN|wxTAB_TRAVERSAL</style>
-          <object class="wxBoxSizer" name="bSizer15">
-            <orient>wxHORIZONTAL</orient>
+          <object class="wxBoxSizer" name="bSizerInit">
+            <orient>wxVERTICAL</orient>
             <object class="sizeritem">
               <flag>wxALL</flag>
               <border>5</border>
               <option>1</option>
-              <object class="wxComboBox" name="m_comboBox7">
-                <value>Combo!</value>
-                <content/>
+              <object class="wxStaticText" name="m_staticTextInitial">
+                <label>Início</label>
+                <wrap>-1</wrap>
+              </object>
+            </object>
+            <object class="sizeritem">
+              <flag>wxEXPAND</flag>
+              <border>5</border>
+              <option>1</option>
+              <object class="wxGridSizer" name="gSizerInit">
+                <rows>0</rows>
+                <cols>2</cols>
+                <vgap>0</vgap>
+                <hgap>0</hgap>
+                <object class="sizeritem">
+                  <flag>wxALL|wxEXPAND</flag>
+                  <border>5</border>
+                  <option>1</option>
+                  <object class="wxPanel" name="m_panelLeft">
+                    <style>wxBORDER_SUNKEN|wxTAB_TRAVERSAL</style>
+                    <object class="wxGridSizer" name="gSizerLeft">
+                      <rows>1</rows>
+                      <cols>1</cols>
+                      <vgap>0</vgap>
+                      <hgap>0</hgap>
+                      <object class="sizeritem">
+                        <flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                        <border>5</border>
+                        <option>0</option>
+                        <object class="wxButton" name="m_buttonRegister">
+                          <label>Registrar</label>
+                          <default>0</default>
+                          <auth_needed>0</auth_needed>
+                          <markup>0</markup>
+                          <bitmap/>
+                        </object>
+                      </object>
+                    </object>
+                  </object>
+                </object>
+                <object class="sizeritem">
+                  <flag>wxEXPAND | wxALL</flag>
+                  <border>5</border>
+                  <option>1</option>
+                  <object class="wxPanel" name="m_panelRight">
+                    <style>wxBORDER_SUNKEN|wxTAB_TRAVERSAL</style>
+                    <object class="wxBoxSizer" name="bSizerRight">
+                      <orient>wxVERTICAL</orient>
+                      <object class="sizeritem">
+                        <flag>wxALL|wxEXPAND</flag>
+                        <border>5</border>
+                        <option>1</option>
+                        <object class="wxStaticText" name="m_staticTextDiets">
+                          <label>Dietas</label>
+                          <wrap>-1</wrap>
+                        </object>
+                      </object>
+                      <object class="sizeritem">
+                        <flag>wxALL|wxEXPAND</flag>
+                        <border>15</border>
+                        <option>9</option>
+                        <object class="wxListBox" name="m_listBoxDiets">
+                          <style>wxLB_SINGLE</style>
+                          <content/>
+                        </object>
+                      </object>
+                    </object>
+                  </object>
+                </object>
               </object>
             </object>
           </object>
         </object>
       </object>
-      <object class="sizeritem">
-        <flag>wxEXPAND | wxALL</flag>
-        <border>5</border>
-        <option>1</option>
-        <object class="wxPanel" name="m_panel12">
-          <style>wxBORDER_SUNKEN|wxTAB_TRAVERSAL</style>
-          <object class="wxBoxSizer" name="bSizer16">
+      <object class="simplebookpage">
+        <label>a page</label>
+        <selected>0</selected>
+        <object class="wxPanel" name="m_panelPageRegister">
+          <style>wxTAB_TRAVERSAL</style>
+          <object class="wxBoxSizer" name="bSizerRegister">
             <orient>wxVERTICAL</orient>
             <object class="sizeritem">
               <flag>wxALL|wxEXPAND</flag>
               <border>5</border>
+              <option>0</option>
+              <object class="wxStaticText" name="m_staticTextRegister">
+                <label>Registrar</label>
+                <wrap>-1</wrap>
+              </object>
+            </object>
+            <object class="sizeritem">
+              <flag>wxEXPAND | wxALL</flag>
+              <border>5</border>
               <option>1</option>
-              <object class="unknown" name="m_dataViewListCtrl4"/>
+              <object class="wxPanel" name="m_panelMainRegister">
+                <style>wxBORDER_SUNKEN|wxTAB_TRAVERSAL</style>
+                <object class="wxGridSizer" name="gSizerMainRegister">
+                  <rows>3</rows>
+                  <cols>2</cols>
+                  <vgap>0</vgap>
+                  <hgap>0</hgap>
+                  <object class="sizeritem">
+                    <flag>wxEXPAND | wxALL</flag>
+                    <border>5</border>
+                    <option>1</option>
+                    <object class="wxPanel" name="m_panelFirst">
+                      <style>wxTAB_TRAVERSAL</style>
+                      <object class="wxGridSizer" name="gSizerFirst">
+                        <rows>1</rows>
+                        <cols>1</cols>
+                        <vgap>0</vgap>
+                        <hgap>0</hgap>
+                        <object class="sizeritem">
+                          <flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+                          <border>5</border>
+                          <option>0</option>
+                          <object class="wxStaticText" name="m_staticTextName">
+                            <label>Nome</label>
+                            <wrap>-1</wrap>
+                          </object>
+                        </object>
+                      </object>
+                    </object>
+                  </object>
+                  <object class="sizeritem">
+                    <flag>wxEXPAND | wxALL</flag>
+                    <border>5</border>
+                    <option>1</option>
+                    <object class="wxPanel" name="m_panelSecond">
+                      <style>wxTAB_TRAVERSAL</style>
+                      <object class="wxGridSizer" name="gSizerSecond">
+                        <rows>1</rows>
+                        <cols>2</cols>
+                        <vgap>0</vgap>
+                        <hgap>0</hgap>
+                        <object class="sizeritem">
+                          <flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
+                          <border>5</border>
+                          <option>0</option>
+                          <object class="wxTextCtrl" name="m_textCtrlName">
+                            <value></value>
+                            <maxlength>0</maxlength>
+                          </object>
+                        </object>
+                      </object>
+                    </object>
+                  </object>
+                  <object class="sizeritem">
+                    <flag>wxEXPAND | wxALL</flag>
+                    <border>5</border>
+                    <option>1</option>
+                    <object class="wxPanel" name="m_panelThird">
+                      <style>wxTAB_TRAVERSAL</style>
+                      <object class="wxGridSizer" name="gSizerThird">
+                        <rows>1</rows>
+                        <cols>1</cols>
+                        <vgap>0</vgap>
+                        <hgap>0</hgap>
+                        <object class="sizeritem">
+                          <flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+                          <border>5</border>
+                          <option>0</option>
+                          <object class="wxStaticText" name="m_staticTextMeal">
+                            <label>Refeição</label>
+                            <wrap>-1</wrap>
+                          </object>
+                        </object>
+                      </object>
+                    </object>
+                  </object>
+                  <object class="sizeritem">
+                    <flag>wxEXPAND | wxALL</flag>
+                    <border>5</border>
+                    <option>1</option>
+                    <object class="wxPanel" name="m_panelFourth">
+                      <style>wxTAB_TRAVERSAL</style>
+                      <object class="wxGridSizer" name="gSizerFourth">
+                        <rows>1</rows>
+                        <cols>1</cols>
+                        <vgap>0</vgap>
+                        <hgap>0</hgap>
+                        <object class="sizeritem">
+                          <flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
+                          <border>5</border>
+                          <option>0</option>
+                          <object class="wxTextCtrl" name="m_textCtrlMeal">
+                            <value></value>
+                            <maxlength>0</maxlength>
+                          </object>
+                        </object>
+                      </object>
+                    </object>
+                  </object>
+                  <object class="spacer">
+                    <flag>wxEXPAND</flag>
+                    <border>5</border>
+                    <option>1</option>
+                    <size>0,0</size>
+                  </object>
+                  <object class="sizeritem">
+                    <flag>wxALL|wxALIGN_BOTTOM|wxALIGN_RIGHT</flag>
+                    <border>5</border>
+                    <option>0</option>
+                    <object class="wxButton" name="m_buttonCreate">
+                      <label>Criar</label>
+                      <default>0</default>
+                      <auth_needed>0</auth_needed>
+                      <markup>0</markup>
+                      <bitmap/>
+                    </object>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object class="simplebookpage">
+        <label>a page</label>
+        <selected>0</selected>
+        <object class="wxPanel" name="m_panelPageCreate">
+          <style>wxTAB_TRAVERSAL</style>
+          <object class="wxFlexGridSizer" name="fgSizerCreate">
+            <vgap>0</vgap>
+            <hgap>0</hgap>
+            <growablerows>1</growablerows>
+            <growablecols>0,1</growablecols>
+            <rows>2</rows>
+            <cols>2</cols>
+            <object class="sizeritem">
+              <flag>wxEXPAND | wxALL</flag>
+              <border>5</border>
+              <option>1</option>
+              <object class="wxPanel" name="m_panelTopLeft">
+                <style>wxTAB_TRAVERSAL</style>
+                <object class="wxGridSizer" name="gSizer4">
+                  <rows>1</rows>
+                  <cols>1</cols>
+                  <vgap>0</vgap>
+                  <hgap>0</hgap>
+                  <object class="sizeritem">
+                    <flag>wxALL|wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT</flag>
+                    <border>5</border>
+                    <option>0</option>
+                    <object class="wxStaticText" name="m_staticText6">
+                      <label>Refeições</label>
+                      <wrap>-1</wrap>
+                    </object>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object class="sizeritem">
+              <flag>wxALL</flag>
+              <border>5</border>
+              <option>0</option>
+              <object class="wxChoice" name="m_choiceMeals">
+                <selection>0</selection>
+                <content/>
+              </object>
+            </object>
+            <object class="sizeritem">
+              <flag>wxEXPAND | wxALL</flag>
+              <border>5</border>
+              <option>1</option>
+              <object class="wxPanel" name="m_panelLeft">
+                <style>wxBORDER_SUNKEN|wxTAB_TRAVERSAL</style>
+                <object class="wxBoxSizer" name="bSizerLeft">
+                  <orient>wxHORIZONTAL</orient>
+                  <object class="sizeritem">
+                    <flag>wxALL</flag>
+                    <border>5</border>
+                    <option>1</option>
+                    <object class="wxComboBox" name="m_comboBoxItems">
+                      <value>Combo!</value>
+                      <content/>
+                    </object>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object class="sizeritem">
+              <flag>wxEXPAND | wxALL</flag>
+              <border>5</border>
+              <option>1</option>
+              <object class="wxPanel" name="m_panelRight">
+                <style>wxBORDER_SUNKEN|wxTAB_TRAVERSAL</style>
+                <object class="wxBoxSizer" name="bSizerRight">
+                  <orient>wxVERTICAL</orient>
+                  <object class="sizeritem">
+                    <flag>wxALL|wxEXPAND</flag>
+                    <border>5</border>
+                    <option>1</option>
+                    <object class="unknown" name="m_dataViewListCtrlMeal"/>
+                  </object>
+                </object>
+              </object>
             </object>
           </object>
         </object>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,12 +2,14 @@ cmake_minimum_required(VERSION 3.5)
 
 add_executable(presentation_test
   presentation_test.cc
+  wx/testableframe.cc
 )
 target_compile_definitions(presentation_test PRIVATE
     __WXGTK__=1
     __WXGTK3__=1
     _FILE_OFFSET_BITS=64
     wxUSE_GUI=1
+    wxUSE_UIACTIONSIMULATOR=1
 )
 target_compile_options(presentation_test PRIVATE ${WX_CFLAGS_OTHER})
 target_include_directories (presentation_test PRIVATE

--- a/test/presentation_test.cc
+++ b/test/presentation_test.cc
@@ -1,32 +1,39 @@
 #define CATCH_CONFIG_RUNNER
 #include "presentation/presentation.h"
 
+#include <wx/app.h>
 #include <wx/filename.h>
 #include <wx/stdpaths.h>
+#include <wx/uiaction.h>
 #include <wx/wx.h>
 #include <wx/xrc/xmlres.h>
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include "core/application.h"
+#include "wx/testableframe.h"
 
 class PresentationTest : public wxApp {
  public:
-  bool OnInit() override {
+  PresentationTest() {}
+
+  virtual bool OnInit() wxOVERRIDE {
     std::vector<const char*> cmd_line_args;
     for (int i = 0; i < argc; ++i) {
       cmd_line_args.push_back(wxString(argv[i]).utf8_string().c_str());
     }
     int result =
         Catch::Session().run(cmd_line_args.size(), cmd_line_args.data());
-    Exit();
     return false;
   }
 };
 
 wxIMPLEMENT_APP(PresentationTest);
 
-TEST_CASE("Presentation", "[Initialize]") {
+#if wxUSE_UIACTIONSIMULATOR
+
+TEST_CASE("Presentation", "[UI Flow]") {
+  wxXmlResource::Get()->InitAllHandlers();
   wxFileName xrc_resources(wxStandardPaths::Get().GetExecutablePath(), "");
   xrc_resources.RemoveLastDir();
   xrc_resources.RemoveLastDir();
@@ -34,18 +41,36 @@ TEST_CASE("Presentation", "[Initialize]") {
   xrc_resources.AppendDir("dietapp");
   xrc_resources.AppendDir("xrc");
   xrc_resources.SetFullName("resource.xrc");
+  wxXmlResource::Get()->Load(xrc_resources.GetFullPath());
 
   Presentation pres(nullptr);
-  REQUIRE(pres.Initialize(xrc_resources));
+  wxTestableFrame* test_frame = wxDynamicCast(
+      wxXmlResource::Get()->LoadFrame(nullptr, "MainFrame"), wxTestableFrame);
+  wxTheApp->SetTopWindow(test_frame);
+  // Use fixed position to facilitate debugging.
+  test_frame->Move(200, 200);
+  REQUIRE(pres.Initialize(xrc_resources, test_frame));
 
-  SECTION("Initialize") {
-    wxFrame* initial_frame =
-        wxXmlResource::Get()->LoadFrame(nullptr, "Initial");
-    wxFrame* register_frame =
-        wxXmlResource::Get()->LoadFrame(nullptr, "Register");
-    wxFrame* create_frame = wxXmlResource::Get()->LoadFrame(nullptr, "Create");
-    REQUIRE(initial_frame != nullptr);
-    REQUIRE(register_frame != nullptr);
-    REQUIRE(create_frame != nullptr);
+  SECTION("Initial Page") {
+    REQUIRE(pres.GetBook()->GetSelection() == 0);
+
+    EventCounter clicked(pres.GetRegisterButton(), wxEVT_BUTTON);
+
+    wxUIActionSimulator sim;
+    wxYield();
+
+    //We move in slightly to account for window decorations, we need to yield
+    //after every wxUIActionSimulator action to keep everything working in GTK
+    sim.MouseMove(pres.GetRegisterButton()->GetScreenPosition() +
+                  wxPoint(10, 10));
+    wxYield();
+
+    sim.MouseClick();
+    wxYield();
+
+    CHECK(clicked.GetCount() == 1);
+    REQUIRE(pres.GetBook()->GetSelection() == 1);
   }
 }
+
+#endif  // wxUSE_UIACTIONSIMULATOR

--- a/test/wx/testableframe.cc
+++ b/test/wx/testableframe.cc
@@ -1,0 +1,76 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        testableframe.cpp
+// Purpose:     An improved wxFrame for unit-testing
+// Author:      Steven Lamerton
+// Copyright:   (c) 2010 Steven Lamerton
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+// For compilers that support precompilation, includes "wx/wx.h".
+// #include "testprec.h"
+#include <catch2/catch_test_macros.hpp>
+
+#include <wx/app.h>
+#include "testableframe.h"
+
+wxTestableFrame::wxTestableFrame() : wxFrame() {}
+
+void wxTestableFrame::OnEvent(wxEvent& evt) {
+  printf("Trigered Event\n");
+  m_count[evt.GetEventType()]++;
+
+  // if (!evt.IsCommandEvent())
+  evt.Skip();
+}
+
+int wxTestableFrame::GetEventCount(wxEventType type) {
+  return m_count[type];
+}
+
+void wxTestableFrame::ClearEventCount(wxEventType type) {
+  m_count[type] = 0;
+}
+
+EventCounter::EventCounter(wxWindow* win, wxEventType type)
+    : m_type(type),
+      m_win(win)
+
+{
+  m_frame = wxStaticCast(wxTheApp->GetTopWindow(), wxTestableFrame);
+
+  m_win->Connect(m_type, wxEventHandler(wxTestableFrame::OnEvent), NULL,
+                 m_frame);
+}
+
+EventCounter::~EventCounter() {
+  m_win->Disconnect(m_type, wxEventHandler(wxTestableFrame::OnEvent), NULL,
+                    m_frame);
+
+  //This stops spurious counts from previous tests
+  Clear();
+
+  m_frame = NULL;
+  m_win = NULL;
+}
+
+bool EventCounter::WaitEvent(int timeInMs) {
+  static const int SINGLE_WAIT_DURATION = 50;
+
+  for (int i = 0; i < timeInMs / SINGLE_WAIT_DURATION; ++i) {
+    wxYield();
+
+    const int count = GetCount();
+    if (count) {
+      CHECK(count == 1);
+
+      Clear();
+      return true;
+    }
+
+    wxMilliSleep(SINGLE_WAIT_DURATION);
+  }
+
+  return false;
+}
+
+wxIMPLEMENT_DYNAMIC_CLASS(wxTestableFrame, wxFrame);

--- a/test/wx/testableframe.h
+++ b/test/wx/testableframe.h
@@ -1,0 +1,49 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        testableframe.h
+// Purpose:     An improved wxFrame for unit-testing
+// Author:      Steven Lamerton
+// Copyright:   (c) 2010 Steven Lamerton
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#include "wx/event.h"
+#include "wx/frame.h"
+#include "wx/hashmap.h"
+
+class wxTestableFrame : public wxFrame {
+  wxDECLARE_DYNAMIC_CLASS(wxTestableFrame);
+
+ public:
+  wxTestableFrame();
+
+  void OnEvent(wxEvent& evt);
+  int GetEventCount(wxEventType type);
+
+ private:
+  friend class EventCounter;
+
+  void ClearEventCount(wxEventType type);
+
+  wxLongToLongHashMap m_count;
+};
+
+class EventCounter {
+ public:
+  EventCounter(wxWindow* win, wxEventType type);
+  ~EventCounter();
+
+  int GetCount() { return m_frame->GetEventCount(m_type); }
+  void Clear() { m_frame->ClearEventCount(m_type); }
+
+  // Sometimes we need to yield a few times before getting the event we
+  // expect, so provide a function waiting for the expected event for up to
+  // the given number of milliseconds (supposed to be divisible by 50).
+  //
+  // Return true if we did receive the event or false otherwise.
+  bool WaitEvent(int timeInMs = 1000);
+
+ private:
+  wxEventType m_type;
+  wxTestableFrame* m_frame;
+  wxWindow* m_win;
+};


### PR DESCRIPTION
Each screen was being represented by a different frame, this caused awkward screen changes, so the proper way to navigate between screens was added with Simplebook. Also add a test that verifies that when the button Register is clicked the app goes to the next page.