### PR TITLE
Run unit tests on workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,8 @@ jobs:
               libgtk-3-dev \
               cmake \
               catch2 \
-              build-essential
+              build-essential \
+              xvfb
               
           wx-config --version-full
           dpkg -l libwxgtk3.2-1t64 | grep ${{ env.WXWIDGETS_VERSION }}
@@ -32,8 +33,12 @@ jobs:
       - name: Configure build
         run: |
           mkdir build && cd build
-          cmake -DCMAKE_BUILD_TYPE=Release ..
+          cmake -DBUILD_TESTING=ON ..
 
       - name: Compile
         run: |
-          cd build && cmake --build . --config Release
+          cd build && cmake --build .
+
+      - name: Run Tests
+        run: |
+          cd build && xvfb-run --auto-servernum -- ./test/presentation_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
-
 project(dietapp VERSION 0.1.0)
+
+option(BUILD_TESTING "Build tests" ON)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
@@ -61,20 +62,22 @@ if(NOT WXSQLITE3_FOUND)
 endif()
 
 add_subdirectory(src)
-add_subdirectory(test)
 
 add_executable(dietapp)
-if(NOT CMAKE_BUILD_TYPE STREQUAL "Release")
-    set(BUILD_RUNTIME_DIR ${CMAKE_BINARY_DIR}/bin)
-
-    set_target_properties(dietapp PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY ${BUILD_RUNTIME_DIR}
-    )
-
-    file(COPY
-        ${CMAKE_SOURCE_DIR}/src/presentation/xrc
-        DESTINATION ${CMAKE_BINARY_DIR}/share/dietapp
-    )
+if(BUILD_TESTING)
+  add_subdirectory(test)
+  add_custom_target(copy_test_resources ALL
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+          ${CMAKE_BINARY_DIR}/share/dietapp
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+          ${CMAKE_BINARY_DIR}/bin
+      COMMAND ${CMAKE_COMMAND} -E copy_directory
+          ${CMAKE_SOURCE_DIR}/src/presentation/xrc
+          ${CMAKE_BINARY_DIR}/share/dietapp/xrc
+  )
+  set_target_properties(dietapp PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
 endif()
 
 target_link_libraries(dietapp PRIVATE application database presentation)

--- a/include/core/application.h
+++ b/include/core/application.h
@@ -5,7 +5,8 @@
 #include <string>
 #include <vector>
 
-#include "core/domain/meal.h"
+#include "core/dto/meal_dto.h"
+#include "core/dto/user_dto.h"
 #include "core/i_application.h"
 
 // Forward declarations
@@ -38,10 +39,15 @@ class Application : public IApplication {
 
   bool IsTestsMode() const override { return false; }
 
-  bool AddMealToUser(const std::string& user_name,
-                     const std::string& meal_name) override;
+  bool CreateUserWithMeal(const CreateUserWithMealDTO& data) override;
 
-  std::vector<Meal> LoadMealsFromUser(const std::string& user_name) override;
+  bool AddMealToUser(const AddMealToUserDTO& data) override;
+
+  std::vector<MealDTO> LoadMealsFromUser(const std::string& username) override;
+
+  bool DoesUserExist(const std::string& username) override;
+
+  UserDTO GetUserData(const std::string& username) override;
 
  private:
   std::unique_ptr<DatabaseManager> db_manager_;

--- a/include/core/domain/user.h
+++ b/include/core/domain/user.h
@@ -5,11 +5,13 @@
 
 class User {
  public:
-  User(int id, const std::string& name);
+  User(int id, const std::string& username, const std::string& display_name);
 
-  User(const std::string& name);
+  User(const std::string& username);
 
-  std::string name() const { return name_; }
+  std::string username() const { return username_; }
+
+  std::string display_name() const { return display_name_; }
 
   void set_id(int id) { id_ = id; }
 
@@ -21,7 +23,8 @@ class User {
 
  private:
   int id_{-1};
-  std::string name_;
+  std::string username_;
+  std::string display_name_;
 };
 
 #endif  // DIETAPP_INCLUDE_CORE_DOMAIN_USER_H

--- a/include/core/dto/meal_dto.h
+++ b/include/core/dto/meal_dto.h
@@ -1,0 +1,18 @@
+#ifndef DIETAPP_INCLUDE_CORE_DTO_MEAL_DTO_H
+#define DIETAPP_INCLUDE_CORE_DTO_MEAL_DTO_H
+
+#include <string>
+#include <vector>
+
+struct MealDTO {
+  std::string name;
+  int user_id;
+};
+
+struct MealsFromUserDTO {
+  std::vector<MealDTO> meals;
+  int selected_meal;
+  int user_id;
+};
+
+#endif // DIETAPP_INCLUDE_CORE_DTO_MEAL_DTO_H

--- a/include/core/dto/user_dto.h
+++ b/include/core/dto/user_dto.h
@@ -1,0 +1,22 @@
+#ifndef DIETAPP_INCLUDE_CORE_DTO_USER_DTO_H
+#define DIETAPP_INCLUDE_CORE_DTO_USER_DTO_H
+
+#include <string>
+
+struct CreateUserWithMealDTO {
+  std::string username;
+  std::string display_name;
+  std::string meal_name;
+};
+
+struct AddMealToUserDTO {
+  std::string username;
+  std::string meal_name;
+};
+
+struct UserDTO {
+  std::string username;
+  std::string display_name;
+};
+
+#endif // DIETAPP_INCLUDE_CORE_DTO_USER_DTO_H

--- a/include/core/i_application.h
+++ b/include/core/i_application.h
@@ -4,15 +4,22 @@
 #include <string>
 #include <vector>
 
-#include "core/domain/meal.h"
+#include "core/dto/meal_dto.h"
+#include "core/dto/user_dto.h"
 
 class IApplication {
  public:
   virtual ~IApplication() = default;
   virtual bool IsTestsMode() const = 0;
-  virtual bool AddMealToUser(const std::string& user_name,
-                             const std::string& meal_name) = 0;
-  virtual std::vector<Meal> LoadMealsFromUser(const std::string& user_name) = 0;
+
+  virtual bool CreateUserWithMeal(const CreateUserWithMealDTO& data) = 0;
+
+  virtual bool AddMealToUser(const AddMealToUserDTO& data) = 0;
+
+  virtual std::vector<MealDTO> LoadMealsFromUser(
+      const std::string& username) = 0;
+  virtual bool DoesUserExist(const std::string& username) = 0;
+  virtual UserDTO GetUserData(const std::string& username) = 0;
 };
 
 #endif  // DIETAPP_INCLUDE_CORE_I_APPLICATION_H

--- a/include/core/ports/repository/user_repository.h
+++ b/include/core/ports/repository/user_repository.h
@@ -9,8 +9,8 @@ class UserRepository {
  public:
   virtual ~UserRepository() = default;
 
-  virtual bool Exists(const std::string& name) const = 0;
-  virtual const User& GetUser(const std::string& name) const = 0;
+  virtual bool Exists(const std::string& username) const = 0;
+  virtual const User& GetUser(const std::string& username) const = 0;
   virtual bool AddUser(User& user) = 0;
   virtual bool DelUser(const User& user) = 0;
   virtual bool UpdateUser(const User& user) = 0;

--- a/include/database/sqlite_user_repository.h
+++ b/include/database/sqlite_user_repository.h
@@ -11,8 +11,8 @@
 #include "database_adapter.h"
 
 constexpr const char* kInsertUserSql = R"sql(
-  INSERT INTO users(name)
-  VALUES (:name)
+  INSERT INTO users(username, display_name)
+  VALUES (:username, :display_name)
 )sql";
 
 constexpr const char* kLoadAllUsers = R"sql(
@@ -23,7 +23,7 @@ class SQLiteUserRepository : public UserRepository {
  public:
   SQLiteUserRepository(std::shared_ptr<DatabaseAdapter> db_adapter);
 
-  bool Exists(const std::string& name) const override;
+  bool Exists(const std::string& username) const override;
 
   const User& GetUser(const std::string& name) const override;
 
@@ -40,8 +40,8 @@ class SQLiteUserRepository : public UserRepository {
  private:
   auto FindByName(const std::string& name) const {
     return std::find_if(users_.begin(), users_.end(),
-                        [&name](const User& user) {    //
-                          return user.name() == name;  //
+                        [&name](const User& user) {        //
+                          return user.username() == name;  //
                         });
   }
 

--- a/include/presentation/error_messages.h
+++ b/include/presentation/error_messages.h
@@ -1,0 +1,14 @@
+#ifndef DIETAPP_INCLUDE_PRESENTATION_ERROR_MESSAGES_H
+#define DIETAPP_INCLUDE_PRESENTATION_ERROR_MESSAGES_H
+
+constexpr char kUserNameErrMsg[] = "Campo nome de usuário é inválido.";
+constexpr char kUserNotFoundErrMsg[] = "Nome de usuário não encontrado.";
+constexpr char kDisplayNameErrMsg[] = "Campo nome é inválido.";
+constexpr char kMealNameErrMsg[] = "Campo refeição é inválido.";
+constexpr char kUserAlreadyExistsErrMsg[] = "Nome de usuário já existe.";
+constexpr char kCreateUserFailedErrMsg[] =
+    "Falha em criar usuário com refeição.";
+constexpr char kMealAddFailedErrMsg[] =
+    "Falha em adicionar refeição ao usuário.";
+
+#endif  // DIETAPP_INCLUDE_PRESENTATION_ERROR_MESSAGES_H

--- a/include/presentation/navigation.h
+++ b/include/presentation/navigation.h
@@ -3,15 +3,19 @@
 
 #include <vector>
 
-#include "core/domain/meal.h"
+#include "core/dto/meal_dto.h"
+#include "core/dto/user_dto.h"
 
-enum class PageId { Initial, Register, Create };
+enum class PageId { Initial, Enter, Register, Create };
 
 class INavigation {
  public:
   virtual ~INavigation() = default;
   virtual void NavigateTo(PageId page) = 0;
-  virtual void NavigateToCreatePageWithMeals(std::vector<Meal> meals) = 0;
+  virtual void NavigateToCreatePageWithMeals(const MealsFromUserDTO& data) = 0;
+  virtual void NavigateToRegisterPageWithNewUser() = 0;
+  virtual void NavigateToRegisterPageWithExistingUser(
+      const UserDTO& user_data) = 0;
 };
 
 #endif  // DIETAPP_INCLUDE_PRESENTATION_NAVIGATION_H

--- a/include/presentation/pages/create_page.h
+++ b/include/presentation/pages/create_page.h
@@ -5,7 +5,7 @@
 
 #include <wx/wx.h>
 
-#include "core/domain/meal.h"
+#include "core/dto/meal_dto.h"
 #include "core/i_application.h"
 #include "presentation/navigation.h"
 
@@ -15,7 +15,7 @@ class CreatePage {
 
   wxChoice* choice_meals() { return choice_meals_; }
 
-  bool SetAvailableChoices(std::vector<Meal> meals);
+  bool SetAvailableChoices(const MealsFromUserDTO& data);
 
  private:
   wxPanel* create_page_;

--- a/include/presentation/pages/register_page.h
+++ b/include/presentation/pages/register_page.h
@@ -1,10 +1,16 @@
 #ifndef DIETAPP_INCLUDE_PRESENTATION_PAGES_REGISTER_PAGE_H
 #define DIETAPP_INCLUDE_PRESENTATION_PAGES_REGISTER_PAGE_H
 
+#include <algorithm>
+#include <functional>
+
 #include <wx/wx.h>
 
 #include "core/i_application.h"
 #include "presentation/navigation.h"
+
+constexpr char kCreateUserLabel[] = "Criar Usuário";
+constexpr char kAddMealLabel[] = "Adicionar Refeição";
 
 class RegisterPage {
  public:
@@ -13,23 +19,52 @@ class RegisterPage {
 
   wxButton* GetCreateButton() { return create_button_; }
 
-  wxTextCtrl* GetNameCtrl() { return name_ctrl_; }
+  wxTextCtrl* GetUsernameCtrl() { return username_ctrl_; }
+
+  wxTextCtrl* GetDisplayNameCtrl() { return display_name_ctrl_; }
 
   wxTextCtrl* GetMealCtrl() { return meal_ctrl_; }
 
   void OnButtonCreate(wxCommandEvent& event);
 
+  void OnButtonBack(wxCommandEvent& event);
+
+  void LoadExistingUser(const UserDTO& user_data);
+
+  void ConfigureForNewUser();
+
+  void ConfigureForExistingUser();
+
  private:
-  void ShowError(const std::string& err_msg);
+  void ShowError(const char* err_msg);
+
+  void ResetTexCtrls();
+
+  bool OnButtonCreateWithNewUser();
+
+  bool OnButtonCreateWithExistingUser();
+
+  bool ValidateTextCtrl(wxTextCtrl* ctrl, wxString& data, const char* err_msg);
+
+  auto FindCurrentMealPos(std::vector<MealDTO>& meals_data) const {
+    return std::find_if(meals_data.begin(), meals_data.end(),       //
+                        [this](const MealDTO& meal) {               //
+                          return meal_.utf8_string() == meal.name;  //
+                        });
+  }
 
   wxPanel* register_page_{nullptr};
   INavigation* navigator_{nullptr};
   IApplication* app_;
   wxButton* create_button_{nullptr};
-  wxTextCtrl* name_ctrl_{nullptr};
+  wxButton* back_button_{nullptr};
+  wxTextCtrl* display_name_ctrl_{nullptr};
   wxTextCtrl* meal_ctrl_{nullptr};
-  wxString name_;
+  wxTextCtrl* username_ctrl_{nullptr};
+  wxString display_name_;
   wxString meal_;
+  wxString username_;
+  std::function<bool()> current_action_;
 };
 
 #endif  // DIETAPP_INCLUDE_PRESENTATION_PAGES_REGISTER_PAGE_H

--- a/include/presentation/presentation.h
+++ b/include/presentation/presentation.h
@@ -8,7 +8,8 @@
 #include <wx/simplebook.h>
 #include <wx/wx.h>
 
-#include "core/domain/meal.h"
+#include "core/dto/meal_dto.h"
+#include "core/dto/user_dto.h"
 #include "core/i_application.h"
 #include "presentation/navigation.h"
 #include "presentation/pages/create_page.h"
@@ -19,7 +20,12 @@ class Presentation : public INavigation {
  public:
   void NavigateTo(PageId page) override;
 
-  void NavigateToCreatePageWithMeals(std::vector<Meal> meals) override;
+  void NavigateToCreatePageWithMeals(const MealsFromUserDTO& data) override;
+
+  void NavigateToRegisterPageWithNewUser() override;
+
+  void NavigateToRegisterPageWithExistingUser(
+      const UserDTO& user_data) override;
 
   Presentation(IApplication* app);
 

--- a/schema-model/schema.sql
+++ b/schema-model/schema.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS "users" (
   `id` INTEGER PRIMARY KEY,
-  `name` TEXT NOT NULL,
   `username` TEXT NOT NULL UNIQUE,
+  `display_name` TEXT NOT NULL,
   `created_at` TEXT NOT NULL DEFAULT current_timestamp
 );
 CREATE TABLE IF NOT EXISTS "foods" (

--- a/src/core/application.cc
+++ b/src/core/application.cc
@@ -7,6 +7,9 @@
 #include <wx/wxsqlite3.h>
 
 #include "core/domain/meal.h"
+#include "core/domain/user.h"
+#include "core/dto/meal_dto.h"
+#include "core/dto/user_dto.h"
 #include "core/ports/repository/meal_repository.h"
 #include "core/ports/repository/user_repository.h"
 #include "database/database_manager.h"
@@ -56,19 +59,19 @@ bool Application::ValidateUserCredentials(const std::string& username,
   return false;
 }
 
-bool Application::AddMealToUser(const std::string& user_name,
-                                const std::string& meal_name) {
+bool Application::CreateUserWithMeal(const CreateUserWithMealDTO& data) {
+
+  if (user_repo_->Exists(data.username)) {
+    return false;
+  }
+
   try {
     db_adapter_->BeginTransaction();
 
-    User user(user_name);
-    if (user_repo_->Exists(user.name()) == false) {
-      user_repo_->AddUser(user);
-    } else {
-      user = user_repo_->GetUser(user_name);
-    }
+    User user(-1, data.username, data.display_name);
+    user_repo_->AddUser(user);
 
-    Meal meal(meal_name);
+    Meal meal(data.meal_name);
     meal_repo_->AddMeal(meal, user.id());
 
     db_adapter_->CommitTransaction();
@@ -79,12 +82,48 @@ bool Application::AddMealToUser(const std::string& user_name,
   return true;
 }
 
-std::vector<Meal> Application::LoadMealsFromUser(const std::string& user_name) {
+bool Application::AddMealToUser(const AddMealToUserDTO& data) {
   try {
-    auto user = user_repo_->GetUser(user_name);
-    return meal_repo_->GetMealsFromUser(user.id());
+    db_adapter_->BeginTransaction();
+
+    const auto user = user_repo_->GetUser(data.username);
+    Meal meal(data.meal_name);
+    meal_repo_->AddMeal(meal, user.id());
+
+    db_adapter_->CommitTransaction();
+  } catch (const wxSQLite3Exception& e) {
+    db_adapter_->RollbackTransaction();
+    return false;
+  }
+  return true;
+}
+
+std::vector<MealDTO> Application::LoadMealsFromUser(
+    const std::string& username) {
+  try {
+    auto user = user_repo_->GetUser(username);
+    auto meals = meal_repo_->GetMealsFromUser(user.id());
+    std::vector<MealDTO> meals_data;
+    MealDTO meal_data;
+    for (const auto& meal : meals) {
+      meal_data.name = meal.name();
+      meal_data.user_id = meal.user_id();
+      meals_data.push_back(meal_data);
+    }
+    return meals_data;
   } catch (const wxSQLite3Exception& e) {
     void();
   }
   return {};
+}
+
+bool Application::DoesUserExist(const std::string& username) {
+  return user_repo_->Exists(username);
+}
+
+UserDTO Application::GetUserData(const std::string& username) {
+  const auto user = user_repo_->GetUser(username);
+  UserDTO user_data = {.username = user.username(),
+                       .display_name = user.display_name()};
+  return user_data;
 }

--- a/src/core/domain/user.cc
+++ b/src/core/domain/user.cc
@@ -1,5 +1,6 @@
 #include "core/domain/user.h"
 
-User::User(const std::string& name) : id_(-1), name_(name) {}
+User::User(const std::string& username) : id_(-1), username_(username) {}
 
-User::User(int id, const std::string& name) : id_(id), name_(name) {}
+User::User(int id, const std::string& username, const std::string& display_name)
+    : id_(id), username_(username), display_name_(display_name) {}

--- a/src/database/sqlite_user_repository.cc
+++ b/src/database/sqlite_user_repository.cc
@@ -10,18 +10,19 @@ SQLiteUserRepository::SQLiteUserRepository(
     std::shared_ptr<DatabaseAdapter> db_adapter)
     : db_adapter_(db_adapter) {}
 
-bool SQLiteUserRepository::Exists(const std::string& name) const {
-  return FindByName(name) != users_.end();
+bool SQLiteUserRepository::Exists(const std::string& username) const {
+  return FindByName(username) != users_.end();
 }
 
-const User& SQLiteUserRepository::GetUser(const std::string& name) const {
-  auto it = FindByName(name);
+const User& SQLiteUserRepository::GetUser(const std::string& username) const {
+  auto it = FindByName(username);
   return *it;
 }
 
 bool SQLiteUserRepository::AddUser(User& user) {
   auto stmt = db_adapter_->Prepare(kInsertUserSql);
-  stmt->Bind(":name", user.name());
+  stmt->Bind(":username", user.username());
+  stmt->Bind(":display_name", user.display_name());
   bool success = stmt->Execute();
   if (success == false) {
     return false;
@@ -47,7 +48,8 @@ bool SQLiteUserRepository::LoadAllUsers() {
   auto stmt = db_adapter_->Prepare(kLoadAllUsers);
   auto result_set = stmt->ExecuteQuery();
   while (result_set->NextRow()) {
-    User user(result_set->GetInt("id"), result_set->GetString("name"));
+    User user(result_set->GetInt("id"), result_set->GetString("username"),
+              result_set->GetString("display_name"));
     users_.insert(user);
   }
   return true;

--- a/src/presentation/pages/create_page.cc
+++ b/src/presentation/pages/create_page.cc
@@ -5,7 +5,6 @@
 #include <wx/wx.h>
 #include <wx/xrc/xmlres.h>
 
-#include "core/domain/meal.h"
 #include "core/i_application.h"
 #include "presentation/navigation.h"
 
@@ -13,15 +12,14 @@ CreatePage::CreatePage(wxPanel* create_page, INavigation* navigator,
                        IApplication* app)
     : create_page_(create_page), navigator_(navigator), app_(app) {
   choice_meals_ = XRCCTRL(*create_page, "m_choiceMeals", wxChoice);
-  if (choice_meals_ == nullptr) {
-    return;
-  }
+  wxASSERT(choice_meals_);
 }
 
-bool CreatePage::SetAvailableChoices(std::vector<Meal> meals) {
-  for (const auto& meal : meals) {
-    choice_meals_->AppendString(wxString(wxString::FromUTF8(meal.name())));
+bool CreatePage::SetAvailableChoices(const MealsFromUserDTO& data) {
+  for (const auto& meal : data.meals) {
+    choice_meals_->AppendString(wxString(meal.name));
   }
-  choice_meals_->SetSelection(0);
+  auto meal_str = wxString(data.meals[data.selected_meal].name);
+  choice_meals_->SetStringSelection(meal_str);
   return true;
 }

--- a/src/presentation/pages/initial_page.cc
+++ b/src/presentation/pages/initial_page.cc
@@ -8,13 +8,13 @@
 InitialPage::InitialPage(wxPanel* initial_page, INavigation* navigator)
     : initial_page_(initial_page), navigator_(navigator) {
   register_button_ = XRCCTRL(*initial_page, "m_buttonRegister", wxButton);
-  if (register_button_ == nullptr) {
-    return;
-  }
+
+  wxASSERT(register_button_);
+
   register_button_->Bind(wxEVT_BUTTON, &InitialPage::OnButtonRegister, this,
                          XRCID(register_button_->GetName()));
 }
 
 void InitialPage::OnButtonRegister(wxCommandEvent& event) {
-  navigator_->NavigateTo(PageId::Register);
+  navigator_->NavigateToRegisterPageWithNewUser();
 }

--- a/src/presentation/pages/register_page.cc
+++ b/src/presentation/pages/register_page.cc
@@ -1,76 +1,147 @@
 #include "presentation/pages/register_page.h"
 
+#include <iterator>
+
 #include <wx/filename.h>
 #include <wx/simplebook.h>
 #include <wx/wx.h>
 #include <wx/xrc/xmlres.h>
 
+#include "core/dto/user_dto.h"
 #include "core/i_application.h"
+#include "presentation/error_messages.h"
 #include "presentation/navigation.h"
 
 RegisterPage::RegisterPage(wxPanel* register_page, INavigation* navigator,
                            IApplication* app)
     : register_page_(register_page), navigator_(navigator), app_(app) {
   create_button_ = XRCCTRL(*register_page, "m_buttonCreate", wxButton);
-  if (create_button_ == nullptr) {
-    return;
-  }
-
-  uint filter = wxFILTER_ASCII |  //
-                wxFILTER_EMPTY |  //
-                wxFILTER_INCLUDE_CHAR_LIST;
-  auto name_validator = wxTextValidator(filter, &name_);
-  auto meal_validator = wxTextValidator(filter, &meal_);
-  wxString included_chars = "ç~^´";
-  name_validator.AddCharIncludes(included_chars);
-  meal_validator.AddCharIncludes(included_chars);
-
-  name_ctrl_ = XRCCTRL(*register_page_, "m_textCtrlName", wxTextCtrl);
-  name_ctrl_->SetValidator(name_validator);
-  if (name_ctrl_ == nullptr) {
-    return;
-  }
-
+  back_button_ = XRCCTRL(*register_page, "m_buttonBack", wxButton);
+  username_ctrl_ = XRCCTRL(*register_page_, "m_textCtrlUsername", wxTextCtrl);
+  display_name_ctrl_ = XRCCTRL(*register_page_, "m_textCtrlName", wxTextCtrl);
   meal_ctrl_ = XRCCTRL(*register_page_, "m_textCtrlMeal", wxTextCtrl);
+
+  wxASSERT(create_button_);
+  wxASSERT(back_button_);
+  wxASSERT(username_ctrl_);
+  wxASSERT(display_name_ctrl_);
+  wxASSERT(meal_ctrl_);
+
+  uint filter_for_alphanum = wxFILTER_ALPHANUMERIC | wxFILTER_EMPTY;
+  auto username_validator = wxTextValidator(filter_for_alphanum, &username_);
+
+  uint filter_for_ascii = wxFILTER_ASCII | wxFILTER_EMPTY;
+  auto display_name_validator =
+      wxTextValidator(filter_for_ascii, &display_name_);
+  auto meal_validator = wxTextValidator(filter_for_ascii, &meal_);
+
+  username_ctrl_->SetValidator(username_validator);
+  display_name_ctrl_->SetValidator(display_name_validator);
   meal_ctrl_->SetValidator(meal_validator);
-  if (meal_ctrl_ == nullptr) {
-    return;
-  }
 
   create_button_->Bind(wxEVT_BUTTON, &RegisterPage::OnButtonCreate, this,
                        XRCID(create_button_->GetName()));
+  back_button_->Bind(wxEVT_BUTTON, &RegisterPage::OnButtonBack, this,
+                     XRCID(back_button_->GetName()));
 }
 
 void RegisterPage::OnButtonCreate(wxCommandEvent& event) {
-  name_ctrl_->TransferDataFromWindow();
-  auto name_validator =
-      wxDynamicCast(name_ctrl_->GetValidator(), wxTextValidator);
-  if (name_validator->IsValid(name_).empty() == false) {
-    ShowError(std::string("Campo nome é inválido."));
+  if (ValidateTextCtrl(username_ctrl_, username_, kUserNameErrMsg) == false) {
     return;
   }
 
-  meal_ctrl_->TransferDataFromWindow();
-  auto meal_validator =
-      wxDynamicCast(meal_ctrl_->GetValidator(), wxTextValidator);
-  if (meal_validator->IsValid(meal_).empty() == false) {
-    ShowError(std::string("Campo refeição é inválido."));
+  if (ValidateTextCtrl(display_name_ctrl_, display_name_, kDisplayNameErrMsg) ==
+      false) {
     return;
   }
 
-  if (app_->AddMealToUser(name_.utf8_string(), meal_.utf8_string()) == false) {
-    ShowError(std::string("Falha em salvar dados."));
+  if (ValidateTextCtrl(meal_ctrl_, meal_, kMealNameErrMsg) == false) {
     return;
   }
 
-  auto user_meals = app_->LoadMealsFromUser(name_.utf8_string());
+  if (current_action_() == false) {
+    return;
+  }
 
-  navigator_->NavigateToCreatePageWithMeals(user_meals);
+  auto meals = app_->LoadMealsFromUser(username_.utf8_string());
+  auto it = FindCurrentMealPos(meals);
+  int selected_index = std::distance(meals.begin(), it);
+  MealsFromUserDTO data{.meals = meals, .selected_meal = selected_index};
+  navigator_->NavigateToCreatePageWithMeals(std::move(data));
 }
 
-void RegisterPage::ShowError(const std::string& err_msg) {
+void RegisterPage::ShowError(const char* err_msg) {
   if (app_->IsTestsMode() == false) {
-    wxMessageBox(wxString(wxString::FromUTF8(err_msg)), wxT("Erro"),
-                 wxICON_ERROR);
+    wxMessageBox(wxString::FromUTF8(err_msg), wxT("Erro"), wxICON_ERROR);
   }
+}
+
+void RegisterPage::OnButtonBack(wxCommandEvent& event) {
+  navigator_->NavigateTo(PageId::Initial);
+  ResetTexCtrls();
+}
+
+void RegisterPage::LoadExistingUser(const UserDTO& user_data) {
+  username_ = wxString(wxString::FromUTF8(user_data.username));
+  display_name_ = wxString(wxString::FromUTF8(user_data.display_name));
+  username_ctrl_->TransferDataToWindow();
+  display_name_ctrl_->TransferDataToWindow();
+  username_ctrl_->SetEditable(false);
+  display_name_ctrl_->SetEditable(false);
+}
+
+void RegisterPage::ResetTexCtrls() {
+  username_ctrl_->SetEditable(true);
+  display_name_ctrl_->SetEditable(true);
+  meal_ctrl_->SetEditable(true);
+}
+
+void RegisterPage::ConfigureForNewUser() {
+  create_button_->SetLabel(wxString::FromUTF8(kCreateUserLabel));
+  current_action_ = [this]() {
+    return OnButtonCreateWithNewUser();
+  };
+}
+
+void RegisterPage::ConfigureForExistingUser() {
+  create_button_->SetLabel(wxString::FromUTF8(kAddMealLabel));
+  current_action_ = [this]() {
+    return OnButtonCreateWithExistingUser();
+  };
+}
+
+bool RegisterPage::OnButtonCreateWithNewUser() {
+  CreateUserWithMealDTO data = {.username = username_.utf8_string(),
+                                .display_name = display_name_.utf8_string(),
+                                .meal_name = meal_.utf8_string()};
+  if (app_->CreateUserWithMeal(std::move(data)) == false) {
+    ShowError(kCreateUserFailedErrMsg);
+    return false;
+  }
+
+  return true;
+}
+
+bool RegisterPage::OnButtonCreateWithExistingUser() {
+  ResetTexCtrls();
+  AddMealToUserDTO data = {.username = username_.utf8_string(),
+                           .meal_name = meal_.utf8_string()};
+  if (app_->AddMealToUser(std::move(data)) == false) {
+    ShowError(kMealAddFailedErrMsg);
+    return false;
+  }
+
+  return true;
+}
+
+bool RegisterPage::ValidateTextCtrl(wxTextCtrl* ctrl, wxString& data,
+                                    const char* err_msg) {
+  ctrl->TransferDataFromWindow();
+  auto validator = wxDynamicCast(ctrl->GetValidator(), wxTextValidator);
+  if (validator->IsValid(data).empty() == false) {
+    ShowError(err_msg);
+    return false;
+  }
+
+  return true;
 }

--- a/src/presentation/presentation.cc
+++ b/src/presentation/presentation.cc
@@ -5,7 +5,6 @@
 #include <wx/wx.h>
 #include <wx/xrc/xmlres.h>
 
-#include "core/domain/meal.h"
 #include "presentation/presentation.h"
 
 Presentation::Presentation(IApplication* app) : app_(app) {}
@@ -48,7 +47,19 @@ void Presentation::NavigateTo(PageId page) {
   book_->SetSelection(static_cast<size_t>(page));
 }
 
-void Presentation::NavigateToCreatePageWithMeals(std::vector<Meal> meals) {
-  create_page_->SetAvailableChoices(meals);
+void Presentation::NavigateToCreatePageWithMeals(const MealsFromUserDTO& data) {
+  create_page_->SetAvailableChoices(data);
   NavigateTo(PageId::Create);
 }
+
+void Presentation::NavigateToRegisterPageWithExistingUser(
+    const UserDTO& user_data) {
+  register_page_->LoadExistingUser(user_data);
+  register_page_->ConfigureForExistingUser();
+  book_->SetSelection(static_cast<size_t>(PageId::Register));
+}
+
+void Presentation::NavigateToRegisterPageWithNewUser() {
+  register_page_->ConfigureForNewUser();
+  book_->SetSelection(static_cast<size_t>(PageId::Register));
+};

--- a/src/presentation/xrc/resource.xrc
+++ b/src/presentation/xrc/resource.xrc
@@ -161,7 +161,7 @@
                         <flag>wxALL|wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT</flag>
                         <border>5</border>
                         <option>0</option>
-                        <object class="wxStaticText" name="m_staticTextUserName">
+                        <object class="wxStaticText" name="m_staticTextUsername">
                           <label>Nome de usuário</label>
                           <wrap>-1</wrap>
                         </object>
@@ -170,16 +170,22 @@
                         <flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
                         <border>5</border>
                         <option>0</option>
-                        <object class="wxTextCtrl" name="m_textCtrlUserName">
+                        <object class="wxTextCtrl" name="m_textCtrlUsername">
                           <value></value>
                           <maxlength>0</maxlength>
                         </object>
                       </object>
-                      <object class="spacer">
-                        <flag>wxEXPAND</flag>
+                      <object class="sizeritem">
+                        <flag>wxALL</flag>
                         <border>5</border>
-                        <option>1</option>
-                        <size>0,0</size>
+                        <option>0</option>
+                        <object class="wxButton" name="m_buttonBack">
+                          <label>Voltar</label>
+                          <default>0</default>
+                          <auth_needed>0</auth_needed>
+                          <markup>0</markup>
+                          <bitmap/>
+                        </object>
                       </object>
                       <object class="sizeritem">
                         <flag>wxALL|wxALIGN_RIGHT|wxALIGN_BOTTOM</flag>
@@ -243,7 +249,7 @@
                           <flag>wxALL|wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT</flag>
                           <border>5</border>
                           <option>0</option>
-                          <object class="wxStaticText" name="m_staticTextUserName1">
+                          <object class="wxStaticText" name="m_staticTextUsername">
                             <label>Nome de Usuário</label>
                             <wrap>-1</wrap>
                           </object>
@@ -266,7 +272,7 @@
                           <flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
                           <border>5</border>
                           <option>0</option>
-                          <object class="wxTextCtrl" name="m_textCtrl3">
+                          <object class="wxTextCtrl" name="m_textCtrlUsername">
                             <value></value>
                             <maxlength>0</maxlength>
                           </object>
@@ -367,7 +373,7 @@
                     </object>
                   </object>
                   <object class="sizeritem">
-                    <flag>wxALL</flag>
+                    <flag>wxALL|wxALIGN_BOTTOM</flag>
                     <border>5</border>
                     <option>0</option>
                     <object class="wxButton" name="m_buttonBack">

--- a/src/presentation/xrc/test_resource.xrc
+++ b/src/presentation/xrc/test_resource.xrc
@@ -161,7 +161,7 @@
                         <flag>wxALL|wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT</flag>
                         <border>5</border>
                         <option>0</option>
-                        <object class="wxStaticText" name="m_staticTextUserName">
+                        <object class="wxStaticText" name="m_staticTextUsername">
                           <label>Nome de usuário</label>
                           <wrap>-1</wrap>
                         </object>
@@ -170,16 +170,22 @@
                         <flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
                         <border>5</border>
                         <option>0</option>
-                        <object class="wxTextCtrl" name="m_textCtrlUserName">
+                        <object class="wxTextCtrl" name="m_textCtrlUsername">
                           <value></value>
                           <maxlength>0</maxlength>
                         </object>
                       </object>
-                      <object class="spacer">
-                        <flag>wxEXPAND</flag>
+                      <object class="sizeritem">
+                        <flag>wxALL</flag>
                         <border>5</border>
-                        <option>1</option>
-                        <size>0,0</size>
+                        <option>0</option>
+                        <object class="wxButton" name="m_buttonBack">
+                          <label>Voltar</label>
+                          <default>0</default>
+                          <auth_needed>0</auth_needed>
+                          <markup>0</markup>
+                          <bitmap/>
+                        </object>
                       </object>
                       <object class="sizeritem">
                         <flag>wxALL|wxALIGN_RIGHT|wxALIGN_BOTTOM</flag>
@@ -243,7 +249,7 @@
                           <flag>wxALL|wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT</flag>
                           <border>5</border>
                           <option>0</option>
-                          <object class="wxStaticText" name="m_staticTextUserName1">
+                          <object class="wxStaticText" name="m_staticTextUsername">
                             <label>Nome de Usuário</label>
                             <wrap>-1</wrap>
                           </object>
@@ -266,7 +272,7 @@
                           <flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
                           <border>5</border>
                           <option>0</option>
-                          <object class="wxTextCtrl" name="m_textCtrl3">
+                          <object class="wxTextCtrl" name="m_textCtrlUsername">
                             <value></value>
                             <maxlength>0</maxlength>
                           </object>
@@ -367,7 +373,7 @@
                     </object>
                   </object>
                   <object class="sizeritem">
-                    <flag>wxALL</flag>
+                    <flag>wxALL|wxALIGN_BOTTOM</flag>
                     <border>5</border>
                     <option>0</option>
                     <object class="wxButton" name="m_buttonBack">

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(presentation_test
   wx/testableframe.cc
   core/fake_application.cc
 )
+add_dependencies(presentation_test copy_test_resources)
 target_compile_definitions(presentation_test PRIVATE
     __WXGTK__=1
     __WXGTK3__=1

--- a/test/core/fake_application.cc
+++ b/test/core/fake_application.cc
@@ -3,12 +3,24 @@
 #include <string>
 #include <vector>
 
-#include "core/domain/meal.h"
-
-bool FakeApplication::AddMealToUser(const std::string&, const std::string&) {
-  return success_;
+bool FakeApplication::CreateUserWithMeal(const CreateUserWithMealDTO& data) {
+  return add_meal_to_user_return_;
 }
 
-std::vector<Meal> FakeApplication::LoadMealsFromUser(const std::string& name) {
-  return std::vector<Meal>();
+bool FakeApplication::AddMealToUser(const AddMealToUserDTO& data) {
+  return true;
+}
+
+std::vector<MealDTO> FakeApplication::LoadMealsFromUser(
+    const std::string& name) {
+  return meals_;
+}
+
+bool FakeApplication::DoesUserExist(const std::string& username) {
+  return does_user_exists_return_;
+}
+
+UserDTO FakeApplication::GetUserData(const std::string& username) {
+  UserDTO user_data = {.username = username, .display_name = ""};
+  return user_data;
 }

--- a/test/core/fake_application.h
+++ b/test/core/fake_application.h
@@ -4,7 +4,8 @@
 #include <string>
 #include <vector>
 
-#include "core/domain/meal.h"
+#include "core/dto/meal_dto.h"
+#include "core/dto/user_dto.h"
 #include "core/i_application.h"
 
 class FakeApplication : public IApplication {
@@ -15,14 +16,32 @@ class FakeApplication : public IApplication {
 
   bool IsTestsMode() const override { return true; }
 
-  bool AddMealToUser(const std::string& name, const std::string& meal) override;
+  bool CreateUserWithMeal(const CreateUserWithMealDTO& data) override;
 
-  std::vector<Meal> LoadMealsFromUser(const std::string& name) override;
+  bool AddMealToUser(const AddMealToUserDTO& data) override;
 
-  void WillReturn(bool success) { success_ = success; }
+  std::vector<MealDTO> LoadMealsFromUser(const std::string& name) override;
+
+  bool DoesUserExist(const std::string& username) override;
+
+  UserDTO GetUserData(const std::string& username) override;
+
+  void AddMealToUserWillReturn(bool success) {
+    add_meal_to_user_return_ = success;
+  }
+
+  void LoadMealsFromUserWillReturn(const MealDTO& meal_data) {
+    meals_.push_back(meal_data);
+  }
+
+  void DoesUserExistsWillReturn(bool success) {
+    does_user_exists_return_ = success;
+  }
 
  private:
-  bool success_ = true;
+  bool add_meal_to_user_return_ = true;
+  bool does_user_exists_return_ = false;
+  std::vector<MealDTO> meals_;
 };
 
 #endif  // DIETAPP_INCLUDE_TEST_APPLICATION_H

--- a/test/presentation_test.cc
+++ b/test/presentation_test.cc
@@ -15,20 +15,22 @@
 
 class PresentationTest : public wxApp {
  public:
-  PresentationTest() {}
-
-  virtual bool OnInit() wxOVERRIDE {
-    std::vector<const char*> cmd_line_args;
-    for (int i = 0; i < argc; ++i) {
-      cmd_line_args.push_back(wxString(argv[i]).utf8_string().c_str());
-    }
-    int result =
-        Catch::Session().run(cmd_line_args.size(), cmd_line_args.data());
-    return false;
-  }
+  bool OnInit() override { return true; }
 };
 
-wxIMPLEMENT_APP(PresentationTest);
+wxIMPLEMENT_APP_NO_MAIN(PresentationTest);
+
+int main(int argc, char** argv) {
+  wxEntryStart(argc, argv);
+  wxTheApp->CallOnInit();
+
+  int result = Catch::Session().run(argc, argv);
+
+  wxTheApp->OnExit();
+  wxEntryCleanup();
+
+  return result;
+}
 
 #if wxUSE_UIACTIONSIMULATOR
 
@@ -52,92 +54,130 @@ TEST_CASE("Presentation", "[UI Flow]") {
   test_frame->Move(200, 200);
   REQUIRE(pres.Initialize(xrc_resources, test_frame));
 
-  SECTION("on register button should go to the next page") {
-    REQUIRE(pres.GetBook()->GetSelection() == 0);
+  std::shared_ptr<InitialPage> initial_page = pres.GetInitialPage();
 
-    EventCounter clicked(pres.GetInitialPage()->GetRegisterButton(),
-                         wxEVT_BUTTON);
+  SECTION("Initial Page: On register button click should go to the next page") {
+    REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Initial);
+
+    EventCounter clicked(initial_page->GetRegisterButton(), wxEVT_BUTTON);
 
     wxUIActionSimulator sim;
     wxYield();
 
     //We move in slightly to account for window decorations, we need to yield
     //after every wxUIActionSimulator action to keep everything working in GTK
-    sim.MouseMove(
-        pres.GetInitialPage()->GetRegisterButton()->GetScreenPosition() +
-        wxPoint(10, 10));
+    sim.MouseMove(initial_page->GetRegisterButton()->GetScreenPosition() +
+                  wxPoint(10, 10));
     wxYield();
 
     sim.MouseClick();
     wxYield();
 
     CHECK(clicked.GetCount() == 1);
-    REQUIRE(pres.GetBook()->GetSelection() == 1);
+    REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Register);
+    clicked.Clear();
 
-    SECTION("on create button with no data should remain in the same page") {
-      REQUIRE(pres.GetBook()->GetSelection() == 1);
+    std::shared_ptr<RegisterPage> register_page = pres.GetRegisterPage();
+    wxButton* reg_create_button = register_page->GetCreateButton();
+    wxTextCtrl* reg_username_ctrl = register_page->GetUsernameCtrl();
+    wxTextCtrl* reg_display_name_ctrl = register_page->GetDisplayNameCtrl();
+    wxTextCtrl* reg_meal_ctrl = register_page->GetMealCtrl();
+    EventCounter username_updated(reg_username_ctrl, wxEVT_TEXT);
+    EventCounter display_name_updated(reg_display_name_ctrl, wxEVT_TEXT);
+    EventCounter meal_updated(reg_meal_ctrl, wxEVT_TEXT);
 
-      sim.MouseMove(
-          pres.GetRegisterPage()->GetCreateButton()->GetScreenPosition() +
-          wxPoint(10, 10));
+    SECTION(
+        "Register Page: On create button with no data should remain in the "
+        "same page") {
+      REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Register);
+      EventCounter clicked(reg_create_button, wxEVT_BUTTON);
+
+      sim.MouseMove(reg_create_button->GetScreenPosition() + wxPoint(10, 10));
       wxYield();
 
       sim.MouseClick();
       wxYield();
 
       CHECK(clicked.GetCount() == 1);
-      REQUIRE(pres.GetBook()->GetSelection() == 1);
+      REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Register);
     }
 
-    SECTION("on create button save data fails should remain on the same page") {
-      static_cast<FakeApplication*>(app)->WillReturn(false);
-      REQUIRE(pres.GetBook()->GetSelection() == 1);
+    SECTION(
+        "Register Page: On create button save data fails should remain on the "
+        "same page") {
+      static_cast<FakeApplication*>(app)->AddMealToUserWillReturn(false);
+      REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Register);
+      EventCounter clicked(reg_create_button, wxEVT_BUTTON);
 
-      sim.MouseMove(
-          pres.GetRegisterPage()->GetCreateButton()->GetScreenPosition() +
-          wxPoint(10, 10));
-      wxYield();
-
-      pres.GetRegisterPage()->GetNameCtrl()->SetFocus();
-      wxYield();
-      sim.Text("John");
+      sim.MouseMove(reg_create_button->GetScreenPosition() + wxPoint(10, 10));
       wxYield();
 
-      pres.GetRegisterPage()->GetMealCtrl()->SetFocus();
-      wxYield();
-      sim.Text("pre training");
-      wxYield();
+      register_page->GetUsernameCtrl()->SetFocus();
+      sim.Text("artorias");
+      while (reg_username_ctrl->GetValue() != wxString("artorias")) {
+        wxYield();
+      }
+      username_updated.Clear();
+
+      register_page->GetDisplayNameCtrl()->SetFocus();
+      sim.Text("The Abysswalker");
+      while (reg_display_name_ctrl->GetValue() != wxString("The Abysswalker")) {
+        wxYield();
+      }
+      display_name_updated.Clear();
+
+      register_page->GetMealCtrl()->SetFocus();
+      sim.Text("darkness");
+      while (reg_meal_ctrl->GetValue() != wxString("darkness")) {
+        wxYield();
+      }
+      meal_updated.Clear();
 
       sim.MouseClick();
       wxYield();
 
       CHECK(clicked.GetCount() == 1);
-      REQUIRE(pres.GetBook()->GetSelection() == 1);
+      REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Register);
+      static_cast<FakeApplication*>(app)->AddMealToUserWillReturn(true);
     }
 
-    SECTION("on create button with valid data should go to the next page") {
-      REQUIRE(pres.GetBook()->GetSelection() == 1);
+    SECTION(
+        "Register Page: On create button with valid data should go to the next "
+        "page") {
+      MealDTO meal{.name = std::string("dragons"), .user_id = 1};
+      static_cast<FakeApplication*>(app)->LoadMealsFromUserWillReturn(meal);
+      REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Register);
+      EventCounter clicked(reg_create_button, wxEVT_BUTTON);
 
-      sim.MouseMove(
-          pres.GetRegisterPage()->GetCreateButton()->GetScreenPosition() +
-          wxPoint(10, 10));
-      wxYield();
-
-      pres.GetRegisterPage()->GetNameCtrl()->SetFocus();
-      wxYield();
-      sim.Text("John");
+      sim.MouseMove(reg_create_button->GetScreenPosition() + wxPoint(10, 10));
       wxYield();
 
-      pres.GetRegisterPage()->GetMealCtrl()->SetFocus();
-      wxYield();
-      sim.Text("pre training");
-      wxYield();
+      register_page->GetUsernameCtrl()->SetFocus();
+      sim.Text("ornstein");
+      while (reg_username_ctrl->GetValue() != wxString("ornstein")) {
+        wxYield();
+      }
+      username_updated.Clear();
+
+      register_page->GetDisplayNameCtrl()->SetFocus();
+      sim.Text("Dragon Slayer");
+      while (reg_display_name_ctrl->GetValue() != wxString("Dragon Slayer")) {
+        wxYield();
+      }
+      display_name_updated.Clear();
+
+      register_page->GetMealCtrl()->SetFocus();
+      sim.Text("dragons");
+      while (reg_meal_ctrl->GetValue() != wxString("dragons")) {
+        wxYield();
+      }
+      meal_updated.Clear();
 
       sim.MouseClick();
       wxYield();
 
       CHECK(clicked.GetCount() == 1);
-      REQUIRE(pres.GetBook()->GetSelection() == 2);
+      REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Create);
     }
   }
 }


### PR DESCRIPTION
Now the unit tests are used to validate the workflow execution. Beside this several refactores and fixes were made, the main ones:

1#: Use DTOs to exchange data between different layers.

2#: Removed check of user existence from presentation layer and added it to the application layer increase layers coherence.

3#: Refactor RegisterPage for better understanding.

4#: Refactor PresentationTest to use a user defined main instead of wxWidgets main.

5#: Fix undefined behaviour of tests, a problem was ocurring during tests in which the text of one textctrl was leaking to the next textctrl causing test checking to fail. The problem was that it was being assumed that the text method of wxUIActionSimulator would fill the entire texctrl before the next instruction something is not always true. Now we wait in a loop until the textctrl has all the text string passed to the text method of wxUIActionSimulator this made the tests 100% deterministic.