### PR TITLE
Add enter page

### DIFF
--- a/include/presentation/pages/enter_page.h
+++ b/include/presentation/pages/enter_page.h
@@ -1,0 +1,29 @@
+#ifndef DIETAPP_INCLUDE_PRESENTATION_PAGES_ENTER_PAGE_H
+#define DIETAPP_INCLUDE_PRESENTATION_PAGES_ENTER_PAGE_H
+
+#include <wx/wx.h>
+
+#include "core/i_application.h"
+#include "presentation/navigation.h"
+
+class EnterPage {
+ public:
+  EnterPage(wxPanel* enter_page, INavigation* navigator, IApplication* app);
+
+  void OnButtonFollowOn(wxCommandEvent& event);
+
+  void OnButtonBack(wxCommandEvent& event);
+
+ private:
+  void ShowError(const char* err_msg);
+
+  wxPanel* enter_page_;
+  INavigation* navigator_;
+  IApplication* app_;
+  wxButton* follow_on_button_;
+  wxButton* back_button_;
+  wxTextCtrl* username_ctrl_;
+  wxString username_;
+};
+
+#endif  // DIETAPP_INCLUDE_PRESENTATION_PAGES_ENTER_PAGE_H

--- a/include/presentation/pages/initial_page.h
+++ b/include/presentation/pages/initial_page.h
@@ -11,11 +11,14 @@ class InitialPage {
 
   void OnButtonRegister(wxCommandEvent& event);
 
+  void OnButtonEnter(wxCommandEvent& event);
+
   wxButton* GetRegisterButton() { return register_button_; }
 
  private:
   wxPanel* initial_page_{nullptr};
   wxButton* register_button_{nullptr};
+  wxButton* enter_button_{nullptr};
   INavigation* navigator_{nullptr};
 };
 

--- a/include/presentation/presentation.h
+++ b/include/presentation/presentation.h
@@ -13,6 +13,7 @@
 #include "core/i_application.h"
 #include "presentation/navigation.h"
 #include "presentation/pages/create_page.h"
+#include "presentation/pages/enter_page.h"
 #include "presentation/pages/initial_page.h"
 #include "presentation/pages/register_page.h"
 
@@ -46,6 +47,7 @@ class Presentation : public INavigation {
   std::shared_ptr<InitialPage> initial_page_;
   std::shared_ptr<RegisterPage> register_page_;
   std::shared_ptr<CreatePage> create_page_;
+  std::shared_ptr<EnterPage> enter_page_;
 };
 
 #endif  // DIETAPP_INCLUDE_PRESENTATION_PRESENTATION_H

--- a/src/presentation/CMakeLists.txt
+++ b/src/presentation/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 add_library(presentation OBJECT
+  pages/enter_page.cc
   pages/initial_page.cc
   pages/register_page.cc
   pages/create_page.cc

--- a/src/presentation/pages/enter_page.cc
+++ b/src/presentation/pages/enter_page.cc
@@ -1,0 +1,58 @@
+#include "presentation/pages/enter_page.h"
+
+#include <wx/wx.h>
+#include <wx/xrc/xmlres.h>
+
+#include "core/i_application.h"
+#include "presentation/error_messages.h"
+#include "presentation/navigation.h"
+
+EnterPage::EnterPage(wxPanel* enter_page, INavigation* navigator,
+                     IApplication* app)
+    : enter_page_(enter_page), navigator_(navigator), app_(app) {
+  follow_on_button_ = XRCCTRL(*enter_page_, "m_buttonFollowOn", wxButton);
+  back_button_ = XRCCTRL(*enter_page_, "m_buttonBack", wxButton);
+  username_ctrl_ = XRCCTRL(*enter_page_, "m_textCtrlUsername", wxTextCtrl);
+  wxASSERT(follow_on_button_);
+  wxASSERT(back_button_);
+  wxASSERT(username_ctrl_);
+
+  uint filter_for_alphanum = wxFILTER_ALPHANUMERIC | wxFILTER_EMPTY;
+  auto username_validator = wxTextValidator(filter_for_alphanum, &username_);
+  username_ctrl_->SetValidator(username_validator);
+
+  follow_on_button_->Bind(wxEVT_BUTTON, &EnterPage::OnButtonFollowOn, this,
+                          XRCID(follow_on_button_->GetName()));
+
+  back_button_->Bind(wxEVT_BUTTON, &EnterPage::OnButtonBack, this,
+                     XRCID(back_button_->GetName()));
+}
+
+void EnterPage::OnButtonFollowOn(wxCommandEvent& event) {
+  username_ctrl_->TransferDataFromWindow();
+  auto username_validator =
+      wxDynamicCast(username_ctrl_->GetValidator(), wxTextValidator);
+  if (username_validator->IsValid(username_).empty() == false) {
+    ShowError(kUserNameErrMsg);
+    return;
+  }
+
+  if (app_->DoesUserExist(username_.utf8_string()) == false) {
+    ShowError(kUserNotFoundErrMsg);
+    return;
+  }
+
+  auto user_data = app_->GetUserData(username_.utf8_string());
+
+  navigator_->NavigateToRegisterPageWithExistingUser(user_data);
+}
+
+void EnterPage::ShowError(const char* err_msg) {
+  if (app_->IsTestsMode() == false) {
+    wxMessageBox(wxString::FromUTF8(err_msg), wxT("Erro"), wxICON_ERROR);
+  }
+}
+
+void EnterPage::OnButtonBack(wxCommandEvent& event) {
+  navigator_->NavigateTo(PageId::Initial);
+}

--- a/src/presentation/pages/initial_page.cc
+++ b/src/presentation/pages/initial_page.cc
@@ -8,13 +8,22 @@
 InitialPage::InitialPage(wxPanel* initial_page, INavigation* navigator)
     : initial_page_(initial_page), navigator_(navigator) {
   register_button_ = XRCCTRL(*initial_page, "m_buttonRegister", wxButton);
+  enter_button_ = XRCCTRL(*initial_page, "m_buttonEnter", wxButton);
 
   wxASSERT(register_button_);
+  wxASSERT(enter_button_);
 
   register_button_->Bind(wxEVT_BUTTON, &InitialPage::OnButtonRegister, this,
                          XRCID(register_button_->GetName()));
+
+  enter_button_->Bind(wxEVT_BUTTON, &InitialPage::OnButtonEnter, this,
+                      XRCID(enter_button_->GetName()));
 }
 
 void InitialPage::OnButtonRegister(wxCommandEvent& event) {
   navigator_->NavigateToRegisterPageWithNewUser();
+}
+
+void InitialPage::OnButtonEnter(wxCommandEvent& event) {
+  navigator_->NavigateTo(PageId::Enter);
 }

--- a/src/presentation/presentation.cc
+++ b/src/presentation/presentation.cc
@@ -34,10 +34,12 @@ bool Presentation::Initialize(wxFileName& xrc_resources, wxFrame* top_window) {
   wxPanel* initial_page = XRCCTRL(*book_, "m_panelPageInit", wxPanel);
   wxPanel* register_page = XRCCTRL(*book_, "m_panelPageRegister", wxPanel);
   wxPanel* create_page = XRCCTRL(*book_, "m_panelPageCreate", wxPanel);
+  wxPanel* enter_page = XRCCTRL(*book_, "m_panelPageEnter", wxPanel);
 
   initial_page_ = std::make_shared<InitialPage>(initial_page, this);
   register_page_ = std::make_shared<RegisterPage>(register_page, this, app_);
   create_page_ = std::make_shared<CreatePage>(create_page, this, app_);
+  enter_page_ = std::make_shared<EnterPage>(enter_page, this, app_);
 
   main_frame_->Show();
   return true;

--- a/test/presentation_test.cc
+++ b/test/presentation_test.cc
@@ -56,7 +56,8 @@ TEST_CASE("Presentation", "[UI Flow]") {
 
   std::shared_ptr<InitialPage> initial_page = pres.GetInitialPage();
 
-  SECTION("Initial Page: On register button click should go to the next page") {
+  SECTION("InitialPageRegisterButtonSucceed",
+          "On register button click should go to the RegisterPage.") {
     REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Initial);
 
     EventCounter clicked(initial_page->GetRegisterButton(), wxEVT_BUTTON);
@@ -86,9 +87,9 @@ TEST_CASE("Presentation", "[UI Flow]") {
     EventCounter display_name_updated(reg_display_name_ctrl, wxEVT_TEXT);
     EventCounter meal_updated(reg_meal_ctrl, wxEVT_TEXT);
 
-    SECTION(
-        "Register Page: On create button with no data should remain in the "
-        "same page") {
+    SECTION("RegisterPageCreateButtonNoData",
+            "On create button click with all forms empty should remain in the "
+            "same page") {
       REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Register);
       EventCounter clicked(reg_create_button, wxEVT_BUTTON);
 
@@ -102,9 +103,105 @@ TEST_CASE("Presentation", "[UI Flow]") {
       REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Register);
     }
 
-    SECTION(
-        "Register Page: On create button save data fails should remain on the "
-        "same page") {
+    SECTION("RegisterPageCreateButtonNoUsername",
+            "On create button click without filling the username field should "
+            "remain in the same page.") {
+      static_cast<FakeApplication*>(app)->AddMealToUserWillReturn(false);
+      REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Register);
+      EventCounter clicked(reg_create_button, wxEVT_BUTTON);
+
+      sim.MouseMove(reg_create_button->GetScreenPosition() + wxPoint(10, 10));
+      wxYield();
+
+      register_page->GetDisplayNameCtrl()->SetFocus();
+      sim.Text("The Abysswalker");
+      while (reg_display_name_ctrl->GetValue() != wxString("The Abysswalker")) {
+        wxYield();
+      }
+      display_name_updated.Clear();
+
+      register_page->GetMealCtrl()->SetFocus();
+      sim.Text("darkness");
+      while (reg_meal_ctrl->GetValue() != wxString("darkness")) {
+        wxYield();
+      }
+      meal_updated.Clear();
+
+      sim.MouseClick();
+      wxYield();
+
+      CHECK(clicked.GetCount() == 1);
+      REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Register);
+      static_cast<FakeApplication*>(app)->AddMealToUserWillReturn(true);
+    }
+
+    SECTION("RegisterPageCreateButtonNoDisplayName",
+            "On create button click without filling the name field should "
+            "remain in the same page.") {
+      static_cast<FakeApplication*>(app)->AddMealToUserWillReturn(false);
+      REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Register);
+      EventCounter clicked(reg_create_button, wxEVT_BUTTON);
+
+      sim.MouseMove(reg_create_button->GetScreenPosition() + wxPoint(10, 10));
+      wxYield();
+
+      register_page->GetUsernameCtrl()->SetFocus();
+      sim.Text("artorias");
+      while (reg_username_ctrl->GetValue() != wxString("artorias")) {
+        wxYield();
+      }
+      username_updated.Clear();
+
+      register_page->GetMealCtrl()->SetFocus();
+      sim.Text("darkness");
+      while (reg_meal_ctrl->GetValue() != wxString("darkness")) {
+        wxYield();
+      }
+      meal_updated.Clear();
+
+      sim.MouseClick();
+      wxYield();
+
+      CHECK(clicked.GetCount() == 1);
+      REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Register);
+      static_cast<FakeApplication*>(app)->AddMealToUserWillReturn(true);
+    }
+
+    SECTION("RegisterPageCreateButtonNoMealName",
+            "On create button click without filling the meal field should "
+            "remain in the same page.") {
+      static_cast<FakeApplication*>(app)->AddMealToUserWillReturn(false);
+      REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Register);
+      EventCounter clicked(reg_create_button, wxEVT_BUTTON);
+
+      sim.MouseMove(reg_create_button->GetScreenPosition() + wxPoint(10, 10));
+      wxYield();
+
+      register_page->GetUsernameCtrl()->SetFocus();
+      sim.Text("artorias");
+      while (reg_username_ctrl->GetValue() != wxString("artorias")) {
+        wxYield();
+      }
+      username_updated.Clear();
+
+      register_page->GetDisplayNameCtrl()->SetFocus();
+      sim.Text("The Abysswalker");
+      while (reg_display_name_ctrl->GetValue() != wxString("The Abysswalker")) {
+        wxYield();
+      }
+      display_name_updated.Clear();
+
+      sim.MouseClick();
+      wxYield();
+
+      CHECK(clicked.GetCount() == 1);
+      REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Register);
+      static_cast<FakeApplication*>(app)->AddMealToUserWillReturn(true);
+    }
+
+    SECTION("RegisterPageCreateButtonAppFails",
+            "On create button click the application layer returns false should "
+            "remain in the same page.") {
       static_cast<FakeApplication*>(app)->AddMealToUserWillReturn(false);
       REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Register);
       EventCounter clicked(reg_create_button, wxEVT_BUTTON);
@@ -142,8 +239,9 @@ TEST_CASE("Presentation", "[UI Flow]") {
     }
 
     SECTION(
-        "Register Page: On create button with valid data should go to the next "
-        "page") {
+        "RegisterPageCreateButtonSucceed"
+        "On create button click filling all the required fields and no error "
+        "occurs on application layer should go to CreatePage.") {
       MealDTO meal{.name = std::string("dragons"), .user_id = 1};
       static_cast<FakeApplication*>(app)->LoadMealsFromUserWillReturn(meal);
       REQUIRE(pres.GetBook()->GetSelection() == (int)PageId::Register);


### PR DESCRIPTION
Add enter page implementation, which is a simple with a username text field and can go further if the user is valid or return to the initial page.

1#: Minor fixes, the tests were renamed using camel case style, this was made to pass individual tests to Catch2 framework. Now we give a detailed description on the description area of the section.