### PR TITLE
Add logic to fill selected foods table

### DIFF
--- a/include/core/application.h
+++ b/include/core/application.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "core/dto/food_dto.h"
 #include "core/dto/meal_dto.h"
 #include "core/dto/user_dto.h"
 #include "core/i_application.h"
@@ -50,6 +51,8 @@ class Application : public IApplication {
   bool DoesUserExist(const std::string& username) override;
 
   UserDTO GetUserData(const std::string& username) override;
+
+  FoodDTO GetFoodData(const std::string& food_name) override;
 
  private:
   std::unique_ptr<DatabaseManager> db_manager_;

--- a/include/core/domain/food.h
+++ b/include/core/domain/food.h
@@ -25,17 +25,17 @@ class Food {
     display_name_ = display_name;
   }
 
-  double protein_per_100g() const { return protein_per_100g_; }
+  double proteins_per_100g() const { return proteins_per_100g_; }
 
-  void set_protein_per_100g(double val) { protein_per_100g_ = val; }
+  void set_proteins_per_100g(double val) { proteins_per_100g_ = val; }
 
-  double carb_per_100g() const { return carb_per_100g_; }
+  double carbs_per_100g() const { return carbs_per_100g_; }
 
-  void set_carb_per_100g(double val) { carb_per_100g_ = val; }
+  void set_carbs_per_100g(double val) { carbs_per_100g_ = val; }
 
-  double fat_per_100g() const { return fat_per_100g_; }
+  double fats_per_100g() const { return fats_per_100g_; }
 
-  void set_fat_per_100g(double val) { fat_per_100g_ = val; }
+  void set_fats_per_100g(double val) { fats_per_100g_ = val; }
 
   bool operator==(const Food& other) const { return id_ == other.id_; }
 
@@ -45,9 +45,9 @@ class Food {
   int id_{-1};
   std::string name_;
   std::string display_name_;
-  double protein_per_100g_;
-  double carb_per_100g_;
-  double fat_per_100g_;
+  double proteins_per_100g_;
+  double carbs_per_100g_;
+  double fats_per_100g_;
 };
 
 #endif  // DIETAPP_INCLUDE_CORE_DOMAIN_FOOD_H

--- a/include/core/dto/food_dto.h
+++ b/include/core/dto/food_dto.h
@@ -7,9 +7,9 @@ struct FoodDTO {
   int id;
   std::string name;
   std::string display_name;
-  double protein_per_100g;
-  double fat_per_100g;
-  double carb_per_100g;
+  double proteins_per_100g;
+  double carbs_per_100g;
+  double fats_per_100g;
 };
 
 #endif // DIETAPP_INCLUDE_CORE_DTO_FOOD_DTO_H

--- a/include/core/i_application.h
+++ b/include/core/i_application.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "core/dto/food_dto.h"
 #include "core/dto/meal_dto.h"
 #include "core/dto/user_dto.h"
 
@@ -27,6 +28,8 @@ class IApplication {
   virtual bool DoesUserExist(const std::string& username) = 0;
 
   virtual UserDTO GetUserData(const std::string& username) = 0;
+
+  virtual FoodDTO GetFoodData(const std::string& food_name) = 0;
 };
 
 #endif  // DIETAPP_INCLUDE_CORE_I_APPLICATION_H

--- a/include/core/ports/repository/food_repository.h
+++ b/include/core/ports/repository/food_repository.h
@@ -10,7 +10,7 @@ class FoodRepository {
  public:
   virtual ~FoodRepository() = default;
 
-  virtual const Food& GetFood(const std::string& food_name) const = 0;
+  virtual const Food GetFood(const std::string& display_name) const = 0;
 
   virtual bool AddFood(Food& food) = 0;
 

--- a/include/database/database_statement.h
+++ b/include/database/database_statement.h
@@ -12,10 +12,15 @@ class DatabaseStatement {
 
   virtual void Bind(const std::string& param_name,
                     const std::string& value) = 0;
+
   virtual void Bind(const std::string& param_name, int value) = 0;
+
+  virtual void Bind(const std::string& param_name, double value) = 0;
+
   // virtual void Bind(int index, double value) = 0;
 
   virtual bool Execute() = 0;
+
   virtual std::unique_ptr<DatabaseResultSet> ExecuteQuery() = 0;
 };
 

--- a/include/database/sqlite_food_repository.h
+++ b/include/database/sqlite_food_repository.h
@@ -1,20 +1,43 @@
 #ifndef DIETAPP_INCLUDE_DATABASE_SQLITE_FOOD_REPOSITORY_H
 #define DIETAPP_INCLUDE_DATABASE_SQLITE_FOOD_REPOSITORY_H
 
-#include <algorithm>
 #include <memory>
-#include <set>
 #include <string>
 
 #include "core/domain/food.h"
 #include "core/ports/repository/food_repository.h"
 #include "database_adapter.h"
 
+constexpr const char* kInsertFoodSql = R"sql(
+  INSERT INTO foods(name,
+                    display_name,
+                    proteins_per_100g,
+                    carbs_per_100g,
+                    fats_per_100g)
+  VALUES (:name,
+          :display_name,
+          :proteins_per_100g,
+          :carbs_per_100g,
+          :fats_per_100g)
+)sql";
+
+constexpr const char* kSelectFoodSql = R"sql(
+  SELECT id, name, proteins_per_100g, carbs_per_100g, fats_per_100g
+  FROM foods
+  WHERE display_name = :display_name
+)sql";
+
+constexpr const char* kCheckTableSql = R"sql(
+  SELECT 1
+  FROM foods
+  LIMIT 1;
+)sql";
+
 class SQLiteFoodRepository : public FoodRepository {
  public:
   SQLiteFoodRepository(std::shared_ptr<DatabaseAdapter> db_adapter);
 
-  const Food& GetFood(const std::string& name) const override;
+  const Food GetFood(const std::string& name) const override;
 
   bool AddFood(Food& food) override;
 
@@ -27,14 +50,6 @@ class SQLiteFoodRepository : public FoodRepository {
   bool FillFoodsTable(const std::vector<Food>& foods) override;
 
  private:
-  auto FindByName(const std::string& name) const {
-    return std::find_if(foods_.begin(), foods_.end(),
-                        [&name](const Food& food) {    //
-                          return food.name() == name;  //
-                        });
-  }
-
-  std::set<Food> foods_;
   std::shared_ptr<DatabaseAdapter> db_adapter_;
 };
 

--- a/include/database/sqlite_statement.h
+++ b/include/database/sqlite_statement.h
@@ -17,6 +17,8 @@ class SQLiteStatement : public DatabaseStatement {
 
   void Bind(const std::string& param_name, int value) override;
 
+  void Bind(const std::string& param_name, double value) override;
+
   bool Execute() override;
 
   std::unique_ptr<DatabaseResultSet> ExecuteQuery() override;

--- a/include/presentation/nutritional_model.h
+++ b/include/presentation/nutritional_model.h
@@ -10,12 +10,11 @@
 
 class NutritionalModel : public wxDataViewModel {
  public:
-  NutritionalModel(const std::vector<FoodDTO> foods);
+  NutritionalModel() = default;
 
   unsigned int GetColumnCount() const override;
 
   bool HasContainerColumns(const wxDataViewItem& item) const override {
-    printf("item: %p\n", item.GetID());
     return false;
   }
 
@@ -34,12 +33,26 @@ class NutritionalModel : public wxDataViewModel {
   unsigned int GetChildren(const wxDataViewItem& parent,
                            wxDataViewItemArray& children) const override;
 
+  FoodDTO GetFoodByRow(unsigned int row);
+
+  void AddFoodToSelection(const FoodDTO& food);
+
+  void DeleteFoodFromSelection(const FoodDTO& food);
+
+  void UpdateSelectedFoods();
+
  private:
   double CalculatePartialKcal(unsigned int row) const;
 
   double CalculateTotalKcal() const;
 
-  const std::vector<FoodDTO> foods_;
+  double CalculateTotalProteinsKcal() const;
+
+  double CalculateTotalCarbsKcal() const;
+
+  double CalculateTotalFatsKcal() const;
+
+  std::vector<FoodDTO> selected_foods_;
 };
 
 #endif  // DIETAPP_INCLUDE_PRESENTATION_NUTRITIONAL_MODEL_H

--- a/include/presentation/pages/create_page.h
+++ b/include/presentation/pages/create_page.h
@@ -30,13 +30,18 @@ class CreatePage {
  private:
   void OnItemSelected(wxCommandEvent& event);
 
+  void OnContextMenuActivated(wxDataViewEvent& event);
+
+  void OnDeleteKey(wxKeyEvent& event);
+
   wxPanel* create_page_;
   INavigation* navigator_;
   IApplication* app_;
   wxChoice* user_meals_;
-  wxComboBox* food_choices_;
+  wxComboBox* food_choices_ctrl_;
   wxDataViewCtrl* selected_foods_ctrl_;
   wxObjectDataPtr<NutritionalModel> model_;
+  std::vector<FoodDTO> foods_data_;
 };
 
 #endif  // DIETAPP_INCLUDE_PRESENTATION_PAGES_CREATE_PAGE_H

--- a/schema-model/schema.sql
+++ b/schema-model/schema.sql
@@ -8,8 +8,8 @@ CREATE TABLE IF NOT EXISTS "foods" (
   `id` INTEGER PRIMARY KEY,
   `name` TEXT NOT NULL,
   `display_name` TEXT NOT NULL,
-  `protein_per_100g` REAL NOT NULL,
-  `carb_per_100g` REAL NOT NULL,
+  `proteins_per_100g` REAL NOT NULL,
+  `carbs_per_100g` REAL NOT NULL,
   `fats_per_100g` REAL NOT NULL
 );
 CREATE TABLE IF NOT EXISTS "meals" (

--- a/src/core/application.cc
+++ b/src/core/application.cc
@@ -48,7 +48,16 @@ bool Application::Initialize() {
   user_repo_->LoadAllUsers();
   meal_repo_->LoadAllMeals();
   xlsx_service_->LoadFoodDataFromSheet(worksheet_name, foods, data);
-  food_repo_->FillFoodsTable(foods);
+
+  try {
+    db_adapter_->BeginTransaction();
+    food_repo_->FillFoodsTable(foods);
+    db_adapter_->CommitTransaction();
+  } catch (const wxSQLite3Exception& e) {
+    std::cerr << e.GetMessage() << std::endl;
+    db_adapter_->RollbackTransaction();
+  }
+
   presentation_->FillFoodChoices(data);
   return true;
 }
@@ -142,4 +151,15 @@ UserDTO Application::GetUserData(const std::string& username) {
   UserDTO user_data = {.username = user.username(),
                        .display_name = user.display_name()};
   return user_data;
+}
+
+FoodDTO Application::GetFoodData(const std::string& food_name) {
+  const auto food = food_repo_->GetFood(food_name);
+  FoodDTO food_data = {.id = food.id(),
+                       .name = food.name(),
+                       .display_name = food.display_name(),
+                       .proteins_per_100g = food.proteins_per_100g(),
+                       .carbs_per_100g = food.carbs_per_100g(),
+                       .fats_per_100g = food.fats_per_100g()};
+  return food_data;
 }

--- a/src/core/xlsx_service.cc
+++ b/src/core/xlsx_service.cc
@@ -91,29 +91,29 @@ bool XlsxService::LoadFoodDataFromSheet(const std::string sheet_name,
       return 0.0;
     };
     const std::string display_name = GenerateDisplayName(name);
-    const double protein_per_100g = parseValue(6);  // Column F
-    const double fat_per_100g = parseValue(7);      // Column G
-    const double carb_per_100g = parseValue(9);     // Column I
+    const double proteins_per_100g = parseValue(6);  // Column F
+    const double fats_per_100g = parseValue(7);      // Column G
+    const double carbs_per_100g = parseValue(9);     // Column I
 
     Food food;
     food.set_id(cellId);
     food.set_name(name);
     food.set_display_name(display_name);
-    food.set_protein_per_100g(protein_per_100g);  // Column F
-    food.set_fat_per_100g(fat_per_100g);          // Column G
-    food.set_carb_per_100g(carb_per_100g);        // Column I
+    food.set_proteins_per_100g(proteins_per_100g);  // Column F
+    food.set_fats_per_100g(fats_per_100g);          // Column G
+    food.set_carbs_per_100g(carbs_per_100g);        // Column I
 
     FoodDTO food_data;
     food_data.id = cellId;
     food_data.name = name;
     food_data.name = display_name;
-    food_data.protein_per_100g = protein_per_100g;
-    food_data.fat_per_100g = fat_per_100g;
-    food_data.carb_per_100g = carb_per_100g;
+    food_data.proteins_per_100g = proteins_per_100g;
+    food_data.fats_per_100g = fats_per_100g;
+    food_data.carbs_per_100g = carbs_per_100g;
     data.push_back(food_data);
 
-    if (food.protein_per_100g() > 0 || food.fat_per_100g() > 0 ||
-        food.carb_per_100g() > 0) {
+    if (food.proteins_per_100g() > 0 || food.fats_per_100g() > 0 ||
+        food.carbs_per_100g() > 0) {
       foods.push_back(food);
     }
   }

--- a/src/database/sqlite_food_repository.cc
+++ b/src/database/sqlite_food_repository.cc
@@ -1,7 +1,10 @@
 #include "database/sqlite_food_repository.h"
 
+#include <iostream>
 #include <memory>
 #include <string>
+
+#include <wx/wxsqlite3.h>
 
 #include "core/domain/food.h"
 #include "database/database_adapter.h"
@@ -10,9 +13,25 @@ SQLiteFoodRepository::SQLiteFoodRepository(
     std::shared_ptr<DatabaseAdapter> db_adapter)
     : db_adapter_(db_adapter) {}
 
-const Food& SQLiteFoodRepository::GetFood(const std::string& food_name) const {
-  auto it = FindByName(food_name);
-  return *it;
+const Food SQLiteFoodRepository::GetFood(
+    const std::string& display_name) const {
+  Food food;
+  try {
+    auto stmt = db_adapter_->Prepare(kSelectFoodSql);
+    stmt->Bind(":display_name", display_name);
+    auto result_set = stmt->ExecuteQuery();
+    while (result_set->NextRow()) {
+      food.set_id(result_set->GetInt("id"));
+      food.set_name(result_set->GetString("name"));
+      food.set_display_name(display_name);
+      food.set_proteins_per_100g(result_set->GetDouble("proteins_per_100g"));
+      food.set_carbs_per_100g(result_set->GetDouble("carbs_per_100g"));
+      food.set_fats_per_100g(result_set->GetDouble("fats_per_100g"));
+    }
+  } catch (const wxSQLite3Exception& e) {
+    std::cerr << e.GetMessage() << std::endl;
+  }
+  return food;
 }
 
 bool SQLiteFoodRepository::AddFood(Food& food) {
@@ -32,5 +51,26 @@ bool SQLiteFoodRepository::LoadAllFoods() {
 }
 
 bool SQLiteFoodRepository::FillFoodsTable(const std::vector<Food>& foods) {
-  return {};
+  auto check_stmt = db_adapter_->Prepare(kCheckTableSql);
+  auto result = check_stmt->ExecuteQuery();
+  if (result->NextRow()) {
+    return true;
+  }
+
+  bool global_success = false;
+  for (const auto& food : foods) {
+    bool local_success = false;
+    auto stmt = db_adapter_->Prepare(kInsertFoodSql);
+    stmt->Bind(":name", food.name());
+    stmt->Bind(":display_name", food.display_name());
+    stmt->Bind(":proteins_per_100g", food.proteins_per_100g());
+    stmt->Bind(":carbs_per_100g", food.carbs_per_100g());
+    stmt->Bind(":fats_per_100g", food.fats_per_100g());
+    local_success = stmt->Execute();
+    if (local_success == false) {
+      global_success = false;
+      continue;
+    }
+  }
+  return global_success;
 }

--- a/src/database/sqlite_result_set.cc
+++ b/src/database/sqlite_result_set.cc
@@ -10,12 +10,11 @@ bool SQLiteResultSet::NextRow() {
   return result_set_.NextRow();
 }
 int SQLiteResultSet::GetInt(const std::string& column_name) {
-  return result_set_.GetInt(wxString(wxString::FromUTF8(column_name)));
+  return result_set_.GetInt(wxString::FromUTF8(column_name));
 }
 std::string SQLiteResultSet::GetString(const std::string& column_name) {
-  return result_set_.GetAsString(wxString(wxString::FromUTF8(column_name)))
-      .utf8_string();
+  return result_set_.GetAsString(wxString::FromUTF8(column_name)).utf8_string();
 }
 double SQLiteResultSet::GetDouble(const std::string& column_name) {
-  return 0;
+  return result_set_.GetDouble(wxString::FromUTF8(column_name), 0);
 }

--- a/src/database/sqlite_statement.cc
+++ b/src/database/sqlite_statement.cc
@@ -12,12 +12,17 @@ SQLiteStatement::SQLiteStatement(wxSQLite3Statement stmt)
 
 void SQLiteStatement::Bind(const std::string& param_name,
                            const std::string& value) {
-  int index = stmt_.GetParamIndex(wxString(param_name));
-  stmt_.Bind(index, wxString(value));
+  int index = stmt_.GetParamIndex(wxString::FromUTF8(param_name));
+  stmt_.Bind(index, wxString::FromUTF8(value));
 }
 
 void SQLiteStatement::Bind(const std::string& param_name, int value) {
-  int index = stmt_.GetParamIndex(wxString(param_name));
+  int index = stmt_.GetParamIndex(wxString::FromUTF8(param_name));
+  stmt_.Bind(index, value);
+}
+
+void SQLiteStatement::Bind(const std::string& param_name, double value) {
+  int index = stmt_.GetParamIndex(wxString::FromUTF8(param_name));
   stmt_.Bind(index, value);
 }
 

--- a/src/presentation/nutritional_model.cc
+++ b/src/presentation/nutritional_model.cc
@@ -1,5 +1,6 @@
 #include "presentation/nutritional_model.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <vector>
 
@@ -7,9 +8,6 @@
 #include <wx/variant.h>
 
 #include "core/dto/food_dto.h"
-
-NutritionalModel::NutritionalModel(const std::vector<FoodDTO> foods)
-    : foods_(foods) {}
 
 unsigned int NutritionalModel::GetColumnCount() const {
   return 5;
@@ -22,16 +20,16 @@ wxString NutritionalModel::GetColumnType(unsigned int col) const {
       type = wxString::FromUTF8("string");
       break;
     case 1:
-      type = wxString::FromUTF8("double");
+      type = wxString::FromUTF8("string");
       break;
     case 2:
-      type = wxString::FromUTF8("double");
+      type = wxString::FromUTF8("string");
       break;
     case 3:
-      type = wxString::FromUTF8("double");
+      type = wxString::FromUTF8("string");
       break;
     case 4:
-      type = wxString::FromUTF8("double");
+      type = wxString::FromUTF8("string");
       break;
     default:
       void();
@@ -42,38 +40,48 @@ wxString NutritionalModel::GetColumnType(unsigned int col) const {
 void NutritionalModel::GetValue(wxVariant& variant, const wxDataViewItem& item,
                                 unsigned int col) const {
   unsigned int row = reinterpret_cast<uintptr_t>(item.GetID()) - 1;
-  if (row < foods_.size()) {
-    const auto& food = foods_[row];
+  if (row < selected_foods_.size()) {
+    const auto& food = selected_foods_[row];
     switch (col) {
       case 0:
-        variant = food.name;
+        variant = wxString::FromUTF8(food.display_name);
         break;
       case 1:
-        variant = food.protein_per_100g;
+        variant = wxString::Format("%.2lf", food.proteins_per_100g);
         break;
       case 2:
-        variant = food.fat_per_100g;
+        variant = wxString::Format("%.2lf", food.carbs_per_100g);
         break;
       case 3:
-        variant = food.carb_per_100g;
+        variant = wxString::Format("%.2lf", food.fats_per_100g);
         break;
       case 4:
-        variant = CalculatePartialKcal(row);
+        variant = wxString::Format("%.2lf", CalculatePartialKcal(row));
         break;
     }
   } else {
     switch (col) {
       case 0:
-        variant =
-            foods_.empty() ? wxString("Sem alimentos") : wxString("Total");
+        variant = selected_foods_.empty() ? wxString("Sem alimentos")
+                                          : wxString("Total");
         break;
       case 1:
+        variant = selected_foods_.empty()
+                      ? wxString::Format("%.2lf", 0.00)
+                      : wxString::Format("%.2lf", CalculateTotalProteinsKcal());
+        break;
       case 2:
+        variant = selected_foods_.empty()
+                      ? wxString::Format("%.2lf", 0.00)
+                      : wxString::Format("%.2lf", CalculateTotalCarbsKcal());
+        break;
       case 3:
-        variant = 0.0;
+        variant = selected_foods_.empty()
+                      ? wxString::Format("%.2lf", 0.00)
+                      : wxString::Format("%.2lf", CalculateTotalFatsKcal());
         break;
       case 4:
-        variant = CalculateTotalKcal();
+        variant = wxString::Format("%.2lf", CalculateTotalKcal());
         break;
     }
   }
@@ -95,7 +103,7 @@ bool NutritionalModel::IsContainer(const wxDataViewItem& item) const {
 unsigned int NutritionalModel::GetChildren(
     const wxDataViewItem& parent, wxDataViewItemArray& children) const {
   if (!parent.IsOk()) {
-    for (unsigned int i = 1; i <= foods_.size() + 1; ++i) {
+    for (unsigned int i = 1; i <= selected_foods_.size() + 1; ++i) {
       children.Add(wxDataViewItem(reinterpret_cast<void*>(i)));
     }
     return children.GetCount();
@@ -103,10 +111,64 @@ unsigned int NutritionalModel::GetChildren(
   return 0;
 }
 
+FoodDTO NutritionalModel::GetFoodByRow(unsigned int row) {
+  return selected_foods_[row];
+}
+
+void NutritionalModel::AddFoodToSelection(const FoodDTO& food) {
+  selected_foods_.push_back(food);
+}
+
+void NutritionalModel::DeleteFoodFromSelection(const FoodDTO& food) {
+  auto new_logical_end =
+      std::remove_if(selected_foods_.begin(), selected_foods_.end(),
+                     [&](const FoodDTO& other) { return food.id == other.id; });
+  selected_foods_.erase(new_logical_end, selected_foods_.end());
+}
+
+void NutritionalModel::UpdateSelectedFoods() {
+  Cleared();
+}
+
 double NutritionalModel::CalculatePartialKcal(unsigned int row) const {
-  return 0;
+  double partial_kcal = 0;
+  for (int i = 0; i <= row; i++) {
+    const auto& food = selected_foods_[i];
+    partial_kcal +=
+        (food.proteins_per_100g + food.carbs_per_100g + food.fats_per_100g);
+  }
+  return partial_kcal;
 }
 
 double NutritionalModel::CalculateTotalKcal() const {
-  return 0;
+  double total_kcal = 0;
+  for (const auto& food : selected_foods_) {
+    total_kcal +=
+        (food.proteins_per_100g + food.carbs_per_100g + food.fats_per_100g);
+  }
+  return total_kcal;
+}
+
+double NutritionalModel::CalculateTotalProteinsKcal() const {
+  double total_proteins_kcal = 00;
+  for (const auto& food : selected_foods_) {
+    total_proteins_kcal += food.proteins_per_100g;
+  }
+  return total_proteins_kcal;
+}
+
+double NutritionalModel::CalculateTotalCarbsKcal() const {
+  double total_carbs_kcal = 00;
+  for (const auto& food : selected_foods_) {
+    total_carbs_kcal += food.carbs_per_100g;
+  }
+  return total_carbs_kcal;
+}
+
+double NutritionalModel::CalculateTotalFatsKcal() const {
+  double total_fats_kcal = 00;
+  for (const auto& food : selected_foods_) {
+    total_fats_kcal += food.fats_per_100g;
+  }
+  return total_fats_kcal;
 }

--- a/src/presentation/pages/create_page.cc
+++ b/src/presentation/pages/create_page.cc
@@ -1,5 +1,6 @@
 #include "presentation/pages/create_page.h"
 
+#include <cstdint>
 #include <vector>
 
 #include <wx/dataview.h>
@@ -14,13 +15,13 @@ CreatePage::CreatePage(wxPanel* create_page, INavigation* navigator,
                        IApplication* app)
     : create_page_(create_page), navigator_(navigator), app_(app) {
   user_meals_ = XRCCTRL(*create_page, "m_choiceMeals", wxChoice);
-  food_choices_ = XRCCTRL(*create_page, "m_comboBoxItems", wxComboBox);
+  food_choices_ctrl_ = XRCCTRL(*create_page, "m_comboBoxItems", wxComboBox);
   wxPanel* right_panel = XRCCTRL(*create_page, "m_panelRight", wxPanel);
   selected_foods_ctrl_ = new wxDataViewCtrl(
       right_panel, wxID_ANY, wxDefaultPosition, wxDefaultSize,
       wxDV_ROW_LINES | wxDV_HORIZ_RULES | wxDV_VERT_RULES);
   wxASSERT(user_meals_);
-  wxASSERT(food_choices_);
+  wxASSERT(food_choices_ctrl_);
   wxASSERT(selected_foods_ctrl_);
 
   wxSizer* sizer = right_panel->GetSizer();
@@ -28,10 +29,10 @@ CreatePage::CreatePage(wxPanel* create_page, INavigation* navigator,
 
   const std::vector<Column> columns{
       {.type = "string", .name = ""},
-      {.type = "double", .name = "Proteínas (kcal)"},
-      {.type = "double", .name = "Gorduras (kcal)"},
-      {.type = "double", .name = "Carboidratos (kcal)"},
-      {.type = "double", .name = "Parcial (kcal)"},
+      {.type = "string", .name = "Proteínas (kcal)"},
+      {.type = "string", .name = "Carboidratos (kcal)"},
+      {.type = "string", .name = "Gorduras (kcal)"},
+      {.type = "string", .name = "Parcial (kcal)"},
   };
 
   for (int col_index = 0; col_index < columns.size(); col_index++) {
@@ -44,11 +45,16 @@ CreatePage::CreatePage(wxPanel* create_page, INavigation* navigator,
     selected_foods_ctrl_->AppendColumn(col);
   }
 
-  model_ = new NutritionalModel({});
+  model_ = new NutritionalModel();
   selected_foods_ctrl_->AssociateModel(model_.get());
 
-  food_choices_->Bind(wxEVT_COMBOBOX, &CreatePage::OnItemSelected, this,
-                      XRCID(food_choices_->GetName()));
+  food_choices_ctrl_->Bind(wxEVT_COMBOBOX, &CreatePage::OnItemSelected, this,
+                           XRCID(food_choices_ctrl_->GetName()));
+
+  selected_foods_ctrl_->Bind(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU,
+                             &CreatePage::OnContextMenuActivated, this);
+
+  selected_foods_ctrl_->Bind(wxEVT_KEY_DOWN, &CreatePage::OnDeleteKey, this);
 }
 
 bool CreatePage::SetMealsFromUser(const MealsFromUserDTO& data) {
@@ -61,14 +67,51 @@ bool CreatePage::SetMealsFromUser(const MealsFromUserDTO& data) {
 }
 
 bool CreatePage::FillFoodChoices(const std::vector<FoodDTO>& data) {
-  for (const auto& food : data) {
-    food_choices_->AppendString(wxString::FromUTF8(food.name));
+  foods_data_ = data;
+  for (const auto& food : foods_data_) {
+    food_choices_ctrl_->AppendString(wxString::FromUTF8(food.name));
   }
-  food_choices_->SetSelection(0);
+  food_choices_ctrl_->SetSelection(0);
   return true;
 }
 
 void CreatePage::OnItemSelected(wxCommandEvent& event) {
-  std::cout << "CreatePage::OnItemSelected" << std::endl;
+  wxString selected_food = food_choices_ctrl_->GetStringSelection();
+  FoodDTO food = app_->GetFoodData(selected_food.utf8_string());
+  model_->AddFoodToSelection(food);
+  model_->UpdateSelectedFoods();
   return;
+}
+
+void CreatePage::OnContextMenuActivated(wxDataViewEvent& event) {
+  printf("CreatePage::OnContextMenuActivated\n");
+  wxDataViewItem item = event.GetItem();
+  if (!item.IsOk())
+    return;
+
+  wxMenu menu;
+  menu.Append(wxID_DELETE, "Excluir Alimento");
+
+  int sel = create_page_->GetPopupMenuSelectionFromUser(menu);
+  if (sel == wxID_DELETE) {
+    unsigned int row = reinterpret_cast<uintptr_t>(item.GetID()) - 1;
+    const FoodDTO& food = model_->GetFoodByRow(row);
+    model_->DeleteFoodFromSelection(food);
+    model_->UpdateSelectedFoods();
+  }
+}
+
+void CreatePage::OnDeleteKey(wxKeyEvent& event) {
+  if (event.GetKeyCode() == WXK_DELETE) {
+    wxDataViewItem item = selected_foods_ctrl_->GetSelection();
+    if (!item.IsOk())
+      return;
+
+    unsigned int row = reinterpret_cast<uintptr_t>(item.GetID()) - 1;
+    const FoodDTO& food = model_->GetFoodByRow(row);
+    model_->DeleteFoodFromSelection(food);
+    model_->UpdateSelectedFoods();
+  } else {
+    event.Skip();
+  }
 }

--- a/test/core/fake_application.cc
+++ b/test/core/fake_application.cc
@@ -32,3 +32,13 @@ UserDTO FakeApplication::GetUserData(const std::string& username) {
   UserDTO user_data = {.username = username, .display_name = ""};
   return user_data;
 }
+
+FoodDTO FakeApplication::GetFoodData(const std::string& food_name) {
+  FoodDTO food_data = {.id = 1,
+                       .name = food_name,
+                       .display_name = "",
+                       .proteins_per_100g = 0,
+                       .carbs_per_100g = 0,
+                       .fats_per_100g = 0};
+  return food_data;
+}

--- a/test/core/fake_application.h
+++ b/test/core/fake_application.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "core/dto/food_dto.h"
 #include "core/dto/meal_dto.h"
 #include "core/dto/user_dto.h"
 #include "core/i_application.h"
@@ -25,6 +26,8 @@ class FakeApplication : public IApplication {
   bool DoesUserExist(const std::string& username) override;
 
   UserDTO GetUserData(const std::string& username) override;
+
+  FoodDTO GetFoodData(const std::string& food_data) override;
 
   void AddMealToUserWillReturn(bool success) {
     add_meal_to_user_return_ = success;


### PR DESCRIPTION
Now its possible to select one item from the list of foods and add or remove it from the table. The removal can be done using the delete key or right clicking mouse. Some minor problems were observed in manual tests, sometimes two items were deleted instead of the selected one, but the calculus of the nutrients remained correct. So this will be corrected in future.

Some features that Create Page lacks right now that will be needed:
1. To let the user enter a custom quantity of a given food
2. Commit the selection of foods to a meal.
3. Back buttons.